### PR TITLE
Add a github-ci script to test compilation on Linux, macOS and Windows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,13 @@ jobs:
     runs-on: ${{matrix.os}}
     steps:
       - uses: actions/checkout@main
-      - run: |
+      - name: prepare-linux
+        if: runner.os == 'Linux'
+        run: |
+            sudo apt-get update
+            sudo apt-get install mesa-common-dev xorg-dev
+      - name: build
+        run: |
           cd example
           cmake -B build
           cmake --build build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+      fail-fast: false
     runs-on: ${{matrix.os}}
     steps:
       - uses: actions/checkout@main

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,16 @@
+name: Build
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{matrix.os}}
+    steps:
+      - uses: actions/checkout@main
+      - run: |
+          cd example
+          cmake -B build
+          cmake --build build


### PR DESCRIPTION
Currently the build fails on macOS and Windows. Both builds are most likely fixed after applying my other PR (https://github.com/brenocq/implot3d/pull/7) - e.g. the Windows build also fails because of the `std::` prefix for math functions.

...in addition there's a lot of warnings in MSVC about double/float conversions which might be worth fixing:

`'initializing': conversion from 'double' to 'float', possible loss of data`

Example CI run in my fork:

https://github.com/floooh/implot3d/actions/runs/12393862255