### PR TITLE
Include <cmath> for std::sin and std::cos

### DIFF
--- a/implot3d.cpp
+++ b/implot3d.cpp
@@ -50,6 +50,7 @@
 
 #include "implot3d.h"
 #include "implot3d_internal.h"
+#include <cmath> // for std::cos, std::sin
 
 #ifndef IMGUI_DISABLE
 


### PR DESCRIPTION
std::sin and std::cos are not part of the std namespace on all build systems. Including cmath fixes the issue. 