### PR TITLE
Add ImPlot3DAxisFlags_Invert flag to invert an axis

### DIFF
--- a/implot3d.h
+++ b/implot3d.h
@@ -248,6 +248,7 @@ enum ImPlot3DAxisFlags_ {
     ImPlot3DAxisFlags_LockMin = 1 << 4,      // The axis minimum value will be locked when panning/zooming
     ImPlot3DAxisFlags_LockMax = 1 << 5,      // The axis maximum value will be locked when panning/zooming
     ImPlot3DAxisFlags_AutoFit = 1 << 6,      // Axis will be auto-fitting to data extents
+    ImPlot3DAxisFlags_Invert = 1 << 7,       // The axis will be inverted
     ImPlot3DAxisFlags_Lock = ImPlot3DAxisFlags_LockMin | ImPlot3DAxisFlags_LockMax,
     ImPlot3DAxisFlags_NoDecorations = ImPlot3DAxisFlags_NoLabel | ImPlot3DAxisFlags_NoGridLines | ImPlot3DAxisFlags_NoTickLabels,
 };


### PR DESCRIPTION
Adding flag `ImPlot3DAxisFlags_Invert` to `ImPlot3DAxisFlags_` to invert an axis. The flag name is the same as the flag in ImPlot. Also added the possibility to invert an axis from the context menu when right-cliking an axis.