### PR TITLE
Fix compatability with IMGUI_DISABLE_OBSOLETE_FUNCTIONS

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ ImPlot3D is an extension of [Dear ImGui](https://github.com/ocornut/imgui) that 
   <a href="https://github.com/brenocq/implot3d/discussions/categories/features-and-improvements?discussions_q=category%3A%22Features+and+improvements%22+label%3Astatus%3Atodo+"><img src="https://storage.googleapis.com/implot3d/todo.svg"/></a>
   <a href="https://github.com/brenocq/implot3d/discussions/categories/features-and-improvements?discussions_q=category%3A%22Features+and+improvements%22+label%3Astatus%3Adoing+"><img src="https://storage.googleapis.com/implot3d/doing.svg"/></a>
   <a href="https://github.com/brenocq/implot3d/discussions/categories/features-and-improvements?discussions_q=category%3A%22Features+and+improvements%22+label%3Astatus%3Areview+"><img src="https://storage.googleapis.com/implot3d/review.svg"/></a>
-  <a href="https://github.com/brenocq/implot3d/discussions/categories/features-and-improvements?discussions_q=category%3A%22Features+and+improvements%22+label%3Astatus%3Adone+"><img src="https://storage.googleapis.com/implot3d/done.svg"/></a>
+  <a href="https://github.com/brenocq/implot3d/discussions/categories/features-and-improvements?discussions_q=category%3A%22Features+and+improvements%22+label%3Astatus%3Adone+is%3Aclosed"><img src="https://storage.googleapis.com/implot3d/done.svg"/></a>
 </div>
 
 <div align="center">

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ ImPlot3D is an extension of [Dear ImGui](https://github.com/ocornut/imgui) that 
 - Default styling based on the current ImGui theme, or completely custom plot styles
 
 ## 🚧 Feature Roadmap
-- ✨ The cards below are automatically updated to reflect the discussions.
+- ✨ The cards below are automatically updated to reflect the [discussions](https://github.com/brenocq/implot3d/discussions).
 - 💡 Click a card to explore the discussion!
 
 <div align="center">

--- a/implot3d.cpp
+++ b/implot3d.cpp
@@ -105,8 +105,7 @@ void AddTextRotated(ImDrawList* draw_list, ImVec2 pos, float angle, ImU32 col, c
     ImFont* font = g.Font;
 
     // Align to be pixel perfect
-    pos.x = IM_FLOOR(pos.x);
-    pos.y = IM_FLOOR(pos.y);
+    pos = ImFloor(pos);
 
     const float scale = g.FontSize / font->FontSize;
 
@@ -2115,22 +2114,22 @@ struct ImPlot3DStyleVarInfo {
 static const ImPlot3DStyleVarInfo GPlot3DStyleVarInfo[] =
     {
         // Item style
-        {ImGuiDataType_Float, 1, (ImU32)IM_OFFSETOF(ImPlot3DStyle, LineWeight)},   // ImPlot3DStyleVar_LineWeight
-        {ImGuiDataType_S32, 1, (ImU32)IM_OFFSETOF(ImPlot3DStyle, Marker)},         // ImPlot3DStyleVar_Marker
-        {ImGuiDataType_Float, 1, (ImU32)IM_OFFSETOF(ImPlot3DStyle, MarkerSize)},   // ImPlot3DStyleVar_MarkerSize
-        {ImGuiDataType_Float, 1, (ImU32)IM_OFFSETOF(ImPlot3DStyle, MarkerWeight)}, // ImPlot3DStyleVar_MarkerWeight
-        {ImGuiDataType_Float, 1, (ImU32)IM_OFFSETOF(ImPlot3DStyle, FillAlpha)},    // ImPlot3DStyleVar_FillAlpha
+        {ImGuiDataType_Float, 1, (ImU32)offsetof(ImPlot3DStyle, LineWeight)},   // ImPlot3DStyleVar_LineWeight
+        {ImGuiDataType_S32, 1, (ImU32)offsetof(ImPlot3DStyle, Marker)},         // ImPlot3DStyleVar_Marker
+        {ImGuiDataType_Float, 1, (ImU32)offsetof(ImPlot3DStyle, MarkerSize)},   // ImPlot3DStyleVar_MarkerSize
+        {ImGuiDataType_Float, 1, (ImU32)offsetof(ImPlot3DStyle, MarkerWeight)}, // ImPlot3DStyleVar_MarkerWeight
+        {ImGuiDataType_Float, 1, (ImU32)offsetof(ImPlot3DStyle, FillAlpha)},    // ImPlot3DStyleVar_FillAlpha
 
         // Plot style
-        {ImGuiDataType_Float, 2, (ImU32)IM_OFFSETOF(ImPlot3DStyle, PlotDefaultSize)}, // ImPlot3DStyleVar_Plot3DDefaultSize
-        {ImGuiDataType_Float, 2, (ImU32)IM_OFFSETOF(ImPlot3DStyle, PlotMinSize)},     // ImPlot3DStyleVar_Plot3DMinSize
-        {ImGuiDataType_Float, 2, (ImU32)IM_OFFSETOF(ImPlot3DStyle, PlotPadding)},     // ImPlot3DStyleVar_Plot3DPadding
+        {ImGuiDataType_Float, 2, (ImU32)offsetof(ImPlot3DStyle, PlotDefaultSize)}, // ImPlot3DStyleVar_Plot3DDefaultSize
+        {ImGuiDataType_Float, 2, (ImU32)offsetof(ImPlot3DStyle, PlotMinSize)},     // ImPlot3DStyleVar_Plot3DMinSize
+        {ImGuiDataType_Float, 2, (ImU32)offsetof(ImPlot3DStyle, PlotPadding)},     // ImPlot3DStyleVar_Plot3DPadding
 
         // Label style
-        {ImGuiDataType_Float, 2, (ImU32)IM_OFFSETOF(ImPlot3DStyle, LabelPadding)},       // ImPlot3DStyleVar_LabelPaddine
-        {ImGuiDataType_Float, 2, (ImU32)IM_OFFSETOF(ImPlot3DStyle, LegendPadding)},      // ImPlot3DStyleVar_LegendPadding
-        {ImGuiDataType_Float, 2, (ImU32)IM_OFFSETOF(ImPlot3DStyle, LegendInnerPadding)}, // ImPlot3DStyleVar_LegendInnerPadding
-        {ImGuiDataType_Float, 2, (ImU32)IM_OFFSETOF(ImPlot3DStyle, LegendSpacing)},      // ImPlot3DStyleVar_LegendSpacing
+        {ImGuiDataType_Float, 2, (ImU32)offsetof(ImPlot3DStyle, LabelPadding)},       // ImPlot3DStyleVar_LabelPaddine
+        {ImGuiDataType_Float, 2, (ImU32)offsetof(ImPlot3DStyle, LegendPadding)},      // ImPlot3DStyleVar_LegendPadding
+        {ImGuiDataType_Float, 2, (ImU32)offsetof(ImPlot3DStyle, LegendInnerPadding)}, // ImPlot3DStyleVar_LegendInnerPadding
+        {ImGuiDataType_Float, 2, (ImU32)offsetof(ImPlot3DStyle, LegendSpacing)},      // ImPlot3DStyleVar_LegendSpacing
 };
 
 static const ImPlot3DStyleVarInfo* GetPlotStyleVarInfo(ImPlot3DStyleVar idx) {


### PR DESCRIPTION
Hello!
I noticed that ImPlot3D currently does not compile when configured with ```IMGUI_DISABLE_OBSOLETE_FUNCTIONS```. In particular, the ```IM_FLOOR``` and ```IM_OFFSETOF``` macros are no longer available in this case. This pull request changes those calls to ```ImFloor``` and C++11's ```offsetof``` respectively.
