### PR TITLE
Implot demo: add link in the readme (+ minor warning fix)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 </div>
 
 <h6 align="center">
-    <a href="https://github.com/brenocq/implot3d#-demos">Demos</a>
+    <a href="https://traineq.org/implot_demo/src/implot_demo.html">Online Demo</a>
     ·
     <a href="https://github.com/brenocq/implot3d/discussions">Discussions</a>
     ·

--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ ImGui::End();
 ## 🎨 Demos
 A comprehensive example showcasing ImPlot3D features can be found in `implot3d_demo.cpp`. Add this file to your project and call `ImPlot3D::ShowDemoWindow()` in your update loop. This demo provides a wide variety of 3D plotting examples, serving as a reference for creating different types of 3D plots. The demo is regularly updated to reflect new features and plot types, so be sure to revisit it with each release!
 
+This demo in also [available online](https://traineq.org/implot_demo/src/implot_demo.html), thanks to [this project](https://github.com/pthom/implot_demo): this way, you can to test ImPlot3D, and ImPlot right away.
+
 ## ⚙️ Integration
 To integrate ImPlot3D into your application, follow these steps:
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ ImGui::End();
 ## 🎨 Demos
 A comprehensive example showcasing ImPlot3D features can be found in `implot3d_demo.cpp`. Add this file to your project and call `ImPlot3D::ShowDemoWindow()` in your update loop. This demo provides a wide variety of 3D plotting examples, serving as a reference for creating different types of 3D plots. The demo is regularly updated to reflect new features and plot types, so be sure to revisit it with each release!
 
-This demo in also [available online](https://traineq.org/implot_demo/src/implot_demo.html), thanks to [this project](https://github.com/pthom/implot_demo): this way, you can to test ImPlot3D, and ImPlot right away.
+This demo in also [available online](https://traineq.org/implot_demo/src/implot_demo.html), thanks to [this project](https://github.com/pthom/implot_demo): this way, you can test ImPlot3D, and ImPlot right away.
 
 ## ⚙️ Integration
 To integrate ImPlot3D into your application, follow these steps:

--- a/implot3d.cpp
+++ b/implot3d.cpp
@@ -1383,7 +1383,7 @@ void EndPlot() {
     for (int i = 0; i < 3; i++) {
         ImPlot3DAxis& axis = plot.Axes[i];
         if (ImGui::BeginPopup(plane_contexts[i])) {
-            ImGui::Text(plane_labels[i]);
+            ImGui::Text("%s", plane_labels[i]);
             ImGui::Separator();
             ShowPlaneContextMenu(plot, i);
             ImGui::EndPopup();


### PR DESCRIPTION
Hi,

Following 
https://github.com/brenocq/implot3d/discussions/25

Here is a PR which adds a link to the demo in the Readme. If you have a better wording proposition please apply it. This is just a suggestion.

---
### About ImGui Bundle integration:

By the way, I added ImPlot3D to ImGui bundle (see [latest commits](https://github.com/pthom/imgui_bundle/commits/main/?since=2025-01-01&until=2025-01-03). It is now available in the C++ and Python side of Dear ImGui Bundle.

The integration went smoothly. I had to make a fork for implot3d, since one part of the API was impossible to port to python without manual adjustments (see [this commit](https://github.com/pthom/implot3d/commit/b6e2e817188233ea76b6e059b694adaad1fb6167) which adapts the API for PlotSurface for Python bindings)

As an example, here is a working python app with Implot3D:

```python
from imgui_bundle import imgui, immapp, implot3d
import numpy as np


def demo3d_lineplots():
    xs1 = np.linspace(0, 1, 1001)
    ys1 = 0.5 + 0.5 * np.cos(50 * (xs1 + imgui.get_time() / 10))
    zs1 = 0.5 + 0.5 * np.sin(50 * (xs1 + imgui.get_time() / 10))

    xs2 = np.linspace(0, 1, 20)
    ys2 = xs2 * xs2
    zs2 = xs2 * ys2

    if implot3d.begin_plot("Line Plots"):
        implot3d.setup_axes("x", "y", "z")
        implot3d.plot_line("f(x)", xs1, ys1, zs1)
        implot3d.set_next_marker_style(implot3d.Marker_.circle.value)
        implot3d.plot_line("g(x)", xs2, ys2, zs2, implot3d.LineFlags_.segments.value)
        implot3d.end_plot()


immapp.run(demo3d_lineplots, with_implot3d=True)
```