### PR TITLE
Box scaling (custom aspect ratios)

### DIFF
--- a/implot3d.cpp
+++ b/implot3d.cpp
@@ -829,7 +829,6 @@ void RenderTickLabels(ImDrawList* draw_list, const ImPlot3DPlot& plot, const ImP
 }
 
 void RenderAxisLabels(ImDrawList* draw_list, const ImPlot3DPlot& plot, const ImPlot3DPoint* corners, const ImVec2* corners_pix, const int axis_corners[3][2]) {
-    ImPlot3DPoint range_center = plot.RangeCenter();
     for (int a = 0; a < 3; a++) {
         const ImPlot3DAxis& axis = plot.Axes[a];
         if (!axis.HasLabel())
@@ -846,12 +845,13 @@ void RenderAxisLabels(ImDrawList* draw_list, const ImPlot3DPlot& plot, const ImP
             continue;
 
         // Position at the end of the axis
-        ImPlot3DPoint label_pos = (corners[idx0] + corners[idx1]) * 0.5f;
+        ImPlot3DPoint label_pos = (PlotToNDC(corners[idx0]) + PlotToNDC(corners[idx1])) * 0.5f;
+        ImPlot3DPoint center_dir = label_pos.Normalized();
         // Add offset
-        label_pos += (label_pos - range_center) * 0.4f;
+        label_pos += center_dir * 0.3f;
 
         // Convert to pixel coordinates
-        ImVec2 label_pos_pix = PlotToPixels(label_pos);
+        ImVec2 label_pos_pix = NDCToPixels(label_pos);
 
         // Adjust label position and angle
         ImU32 col_ax_txt = GetStyleColorU32(ImPlot3DCol_AxisText);

--- a/implot3d.cpp
+++ b/implot3d.cpp
@@ -713,8 +713,8 @@ void RenderTickMarks(ImDrawList* draw_list, const ImPlot3DPlot& plot, const ImPl
         tick_dir.Normalize();
 
         // Tick lengths in NDC units
-        const float major_size_ndc = 0.06f;
-        const float minor_size_ndc = 0.03f;
+        const float major_size_ndc = 0.06f / plot.BoxScale;
+        const float minor_size_ndc = 0.03f / plot.BoxScale;
 
         for (int t = 0; t < axis.Ticker.TickCount(); ++t) {
             const ImPlot3DTick& tick = axis.Ticker.Ticks[t];

--- a/implot3d.cpp
+++ b/implot3d.cpp
@@ -1480,6 +1480,16 @@ void SetupLegend(ImPlot3DLocation location, ImPlot3DLegendFlags flags) {
     legend.PreviousFlags = flags;
 }
 
+void SetupBoxAspect(float x, float y, float z) {
+    ImPlot3DContext& gp = *GImPlot3D;
+    IM_ASSERT_USER_ERROR(gp.CurrentPlot != nullptr && !gp.CurrentPlot->SetupLocked,
+                         "SetupBoxAspect() needs to be called after BeginPlot() and before any setup locking functions (e.g. PlotX)!");
+    ImPlot3DPlot& plot = *gp.CurrentPlot;
+    plot.BoxAspect = ImPlot3DPoint(x, y, z);
+    float max = ImMax(x, ImMax(y, z));
+    plot.BoxAspect /= max;
+}
+
 //-----------------------------------------------------------------------------
 // [SECTION] Plot Utils
 //-----------------------------------------------------------------------------

--- a/implot3d.h
+++ b/implot3d.h
@@ -372,6 +372,8 @@ IMPLOT3D_API void SetupAxesLimits(double x_min, double x_max, double y_min, doub
 
 IMPLOT3D_API void SetupLegend(ImPlot3DLocation location, ImPlot3DLegendFlags flags = 0);
 
+IMPLOT3D_API void SetupBoxAspect(float x, float y, float z);
+
 //-----------------------------------------------------------------------------
 // [SECTION] Plot Items
 //-----------------------------------------------------------------------------

--- a/implot3d.h
+++ b/implot3d.h
@@ -370,9 +370,15 @@ IMPLOT3D_API void SetupAxes(const char* x_label, const char* y_label, const char
 // Sets the X/Y/Z axes range limits. If ImPlotCond_Always is used, the axes limits will be locked (shorthand for two calls to SetupAxisLimits)
 IMPLOT3D_API void SetupAxesLimits(double x_min, double x_max, double y_min, double y_max, double z_min, double z_max, ImPlot3DCond cond = ImPlot3DCond_Once);
 
-IMPLOT3D_API void SetupLegend(ImPlot3DLocation location, ImPlot3DLegendFlags flags = 0);
-
+// Sets the aspect ratio between the X, Y, and Z axes for the 3D plot box (values must be positive).
+// An aspect ratio of 1:1:1 represents equal ratio across all axes (default plot cube).
 IMPLOT3D_API void SetupBoxAspect(float x, float y, float z);
+
+// Scales the entire 3D plot box uniformly along all axes. A scale of 1.0 is the default.
+// Values greater than 1.0 enlarge the plot, while values between 0.0 and 1.0 shrink it.
+IMPLOT3D_API void SetupBoxScale(float scale);
+
+IMPLOT3D_API void SetupLegend(ImPlot3DLocation location, ImPlot3DLegendFlags flags = 0);
 
 //-----------------------------------------------------------------------------
 // [SECTION] Plot Items

--- a/implot3d.h
+++ b/implot3d.h
@@ -370,13 +370,8 @@ IMPLOT3D_API void SetupAxes(const char* x_label, const char* y_label, const char
 // Sets the X/Y/Z axes range limits. If ImPlotCond_Always is used, the axes limits will be locked (shorthand for two calls to SetupAxisLimits)
 IMPLOT3D_API void SetupAxesLimits(double x_min, double x_max, double y_min, double y_max, double z_min, double z_max, ImPlot3DCond cond = ImPlot3DCond_Once);
 
-// Sets the aspect ratio between the X, Y, and Z axes for the 3D plot box (values must be positive).
-// An aspect ratio of 1:1:1 represents equal ratio across all axes (default plot cube).
-IMPLOT3D_API void SetupBoxAspect(float x, float y, float z);
-
-// Scales the entire 3D plot box uniformly along all axes. A scale of 1.0 is the default.
-// Values greater than 1.0 enlarge the plot, while values between 0.0 and 1.0 shrink it.
-IMPLOT3D_API void SetupBoxScale(float scale);
+// Sets the plot box X/Y/Z scale. A scale of 1.0 is the default. Values greater than 1.0 enlarge the plot, while values between 0.0 and 1.0 shrink it.
+IMPLOT3D_API void SetupBoxScale(float x, float y, float z);
 
 IMPLOT3D_API void SetupLegend(ImPlot3DLocation location, ImPlot3DLegendFlags flags = 0);
 

--- a/implot3d_demo.cpp
+++ b/implot3d_demo.cpp
@@ -15,10 +15,16 @@
 // [SECTION] User Namespace
 // [SECTION] Helpers
 // [SECTION] Plots
+// [SECTION] Axes
 // [SECTION] Custom
 // [SECTION] Demo Window
 // [SECTION] Style Editor
 // [SECTION] User Namespace Implementation
+
+// We define this to avoid accidentally using the deprecated API
+#ifndef IMPLOT_DISABLE_OBSOLETE_FUNCTIONS
+#define IMPLOT_DISABLE_OBSOLETE_FUNCTIONS
+#endif
 
 #include "implot3d.h"
 #include "implot3d_internal.h"
@@ -536,6 +542,24 @@ void DemoNaNValues() {
 }
 
 //-----------------------------------------------------------------------------
+// [SECTION] Axes
+//-----------------------------------------------------------------------------
+
+void DemoBoxAspectScale() {
+    static float aspect[3] = {1.0f, 1.0f, 1.0f};
+    static float scale = 1.0f;
+
+    ImGui::SliderFloat3("Box Aspect Ratio", aspect, 0.1f, 5.0f, "%.1f");
+    ImGui::SliderFloat("Box Scale", &scale, 0.1f, 5.0f, "%.1f");
+
+    if (ImPlot3D::BeginPlot("##BoxAspectRatio")) {
+        ImPlot3D::SetupBoxAspect(aspect[0], aspect[1], aspect[2]);
+        ImPlot3D::SetupBoxScale(scale);
+        ImPlot3D::EndPlot();
+    }
+}
+
+//-----------------------------------------------------------------------------
 // [SECTION] Custom
 //-----------------------------------------------------------------------------
 
@@ -719,6 +743,10 @@ void ShowDemoWindow(bool* p_open) {
             DemoHeader("Realtime Plots", DemoRealtimePlots);
             DemoHeader("Markers and Text", DemoMarkersAndText);
             DemoHeader("NaN Values", DemoNaNValues);
+            ImGui::EndTabItem();
+        }
+        if (ImGui::BeginTabItem("Axes")) {
+            DemoHeader("Box Aspect & Scale", DemoBoxAspectScale);
             ImGui::EndTabItem();
         }
         if (ImGui::BeginTabItem("Custom")) {

--- a/implot3d_demo.cpp
+++ b/implot3d_demo.cpp
@@ -546,12 +546,21 @@ void DemoNaNValues() {
 //-----------------------------------------------------------------------------
 
 void DemoBoxScale() {
-    static float scale[3] = {1.0f, 1.0f, 1.0f};
+    constexpr int N = 100;
+    float xs[N], ys[N], zs[N];
+    for (int i = 0; i < N; ++i) {
+        float t = i / (float)(N - 1);
+        xs[i] = sinf(t * 2.0f * IM_PI);
+        ys[i] = cosf(t * 4.0f * IM_PI);
+        zs[i] = t * 2.0f - 1.0f;
+    }
 
-    ImGui::SliderFloat3("Box Scale", scale, 0.1f, 5.0f, "%.2f");
+    static float scale[3] = {1.0f, 1.0f, 1.0f};
+    ImGui::SliderFloat3("Box Scale", scale, 0.1f, 2.0f, "%.2f");
 
     if (ImPlot3D::BeginPlot("##BoxScale")) {
         ImPlot3D::SetupBoxScale(scale[0], scale[1], scale[2]);
+        ImPlot3D::PlotLine("3D Curve", xs, ys, zs, N);
         ImPlot3D::EndPlot();
     }
 }

--- a/implot3d_demo.cpp
+++ b/implot3d_demo.cpp
@@ -549,8 +549,8 @@ void DemoBoxAspectScale() {
     static float aspect[3] = {1.0f, 1.0f, 1.0f};
     static float scale = 1.0f;
 
-    ImGui::SliderFloat3("Box Aspect Ratio", aspect, 0.1f, 5.0f, "%.1f");
-    ImGui::SliderFloat("Box Scale", &scale, 0.1f, 5.0f, "%.1f");
+    ImGui::SliderFloat3("Box Aspect Ratio", aspect, 0.1f, 5.0f, "%.2f");
+    ImGui::SliderFloat("Box Scale", &scale, 0.1f, 3.0f, "%.2f");
 
     if (ImPlot3D::BeginPlot("##BoxAspectRatio")) {
         ImPlot3D::SetupBoxAspect(aspect[0], aspect[1], aspect[2]);

--- a/implot3d_demo.cpp
+++ b/implot3d_demo.cpp
@@ -545,16 +545,13 @@ void DemoNaNValues() {
 // [SECTION] Axes
 //-----------------------------------------------------------------------------
 
-void DemoBoxAspectScale() {
-    static float aspect[3] = {1.0f, 1.0f, 1.0f};
-    static float scale = 1.0f;
+void DemoBoxScale() {
+    static float scale[3] = {1.0f, 1.0f, 1.0f};
 
-    ImGui::SliderFloat3("Box Aspect Ratio", aspect, 0.1f, 5.0f, "%.2f");
-    ImGui::SliderFloat("Box Scale", &scale, 0.1f, 3.0f, "%.2f");
+    ImGui::SliderFloat3("Box Scale", scale, 0.1f, 5.0f, "%.2f");
 
-    if (ImPlot3D::BeginPlot("##BoxAspectRatio")) {
-        ImPlot3D::SetupBoxAspect(aspect[0], aspect[1], aspect[2]);
-        ImPlot3D::SetupBoxScale(scale);
+    if (ImPlot3D::BeginPlot("##BoxScale")) {
+        ImPlot3D::SetupBoxScale(scale[0], scale[1], scale[2]);
         ImPlot3D::EndPlot();
     }
 }
@@ -746,7 +743,7 @@ void ShowDemoWindow(bool* p_open) {
             ImGui::EndTabItem();
         }
         if (ImGui::BeginTabItem("Axes")) {
-            DemoHeader("Box Aspect & Scale", DemoBoxAspectScale);
+            DemoHeader("Box Scale", DemoBoxScale);
             ImGui::EndTabItem();
         }
         if (ImGui::BeginTabItem("Custom")) {

--- a/implot3d_internal.h
+++ b/implot3d_internal.h
@@ -109,7 +109,7 @@ struct ImPlot3DTicker;
 // [SECTION] Callbacks
 //------------------------------------------------------------------------------
 
-typedef void (*ImPlot3DLocator)(ImPlot3DTicker& ticker, const ImPlot3DRange& range, ImPlot3DFormatter formatter, void* formatter_data);
+typedef void (*ImPlot3DLocator)(ImPlot3DTicker& ticker, const ImPlot3DRange& range, float pixels, ImPlot3DFormatter formatter, void* formatter_data);
 
 //-----------------------------------------------------------------------------
 // [SECTION] Structs
@@ -686,7 +686,7 @@ int Formatter_Default(float value, char* buff, int size, void* data);
 // [SECTION] Locator
 //------------------------------------------------------------------------------
 
-void Locator_Default(ImPlot3DTicker& ticker, const ImPlot3DRange& range, ImPlot3DFormatter formatter, void* formatter_data);
+void Locator_Default(ImPlot3DTicker& ticker, const ImPlot3DRange& range, float pixels, ImPlot3DFormatter formatter, void* formatter_data);
 
 } // namespace ImPlot3D
 

--- a/implot3d_internal.h
+++ b/implot3d_internal.h
@@ -521,10 +521,11 @@ struct ImPlot3DPlot {
     ImRect FrameRect;  // Outermost bounding rectangle that encapsulates whole the plot/title/padding/etc
     ImRect CanvasRect; // Frame rectangle reduced by padding
     ImRect PlotRect;   // Bounding rectangle for the actual plot area
-    // Plot box state
+    // Rotation & axes
     ImPlot3DQuat Rotation;   // Current rotation quaternion
     ImPlot3DAxis Axes[3];    // X, Y, Z axes
-    ImPlot3DPoint BoxAspect; // Aspect ratio of the plot box
+    ImPlot3DPoint BoxAspect; // Aspect ratio of the X, Y, Z axes of the plot box
+    float BoxScale;          // Scales the plot box uniformly along all axes
     // Animation
     float AnimationTime;               // Remaining animation time
     ImPlot3DQuat RotationAnimationEnd; // End rotation for animation
@@ -553,6 +554,7 @@ struct ImPlot3DPlot {
         for (int i = 0; i < 3; i++)
             Axes[i] = ImPlot3DAxis();
         BoxAspect = ImPlot3DPoint(1.0f, 1.0f, 1.0f);
+        BoxScale = 1.0f;
         AnimationTime = 0.0f;
         RotationAnimationEnd = Rotation;
         SetupLocked = false;
@@ -578,6 +580,7 @@ struct ImPlot3DPlot {
     ImPlot3DPoint RangeMax() const;
     ImPlot3DPoint RangeCenter() const;
     void SetRange(const ImPlot3DPoint& min, const ImPlot3DPoint& max);
+    float GetBoxZoom() const;
 };
 
 struct ImPlot3DContext {

--- a/implot3d_internal.h
+++ b/implot3d_internal.h
@@ -521,11 +521,10 @@ struct ImPlot3DPlot {
     ImRect FrameRect;  // Outermost bounding rectangle that encapsulates whole the plot/title/padding/etc
     ImRect CanvasRect; // Frame rectangle reduced by padding
     ImRect PlotRect;   // Bounding rectangle for the actual plot area
-    // Rotation & axes
-    ImPlot3DQuat Rotation;   // Current rotation quaternion
-    ImPlot3DAxis Axes[3];    // X, Y, Z axes
-    ImPlot3DPoint BoxAspect; // Aspect ratio of the X, Y, Z axes of the plot box
-    float BoxScale;          // Scales the plot box uniformly along all axes
+    // Rotation & axes & box
+    ImPlot3DQuat Rotation;  // Current rotation quaternion
+    ImPlot3DAxis Axes[3];   // X, Y, Z axes
+    ImPlot3DPoint BoxScale; // Scale factor for plot box X, Y, Z axes
     // Animation
     float AnimationTime;               // Remaining animation time
     ImPlot3DQuat RotationAnimationEnd; // End rotation for animation
@@ -553,8 +552,7 @@ struct ImPlot3DPlot {
         Rotation = ImPlot3DQuat(0.0f, 0.0f, 0.0f, 1.0f);
         for (int i = 0; i < 3; i++)
             Axes[i] = ImPlot3DAxis();
-        BoxAspect = ImPlot3DPoint(1.0f, 1.0f, 1.0f);
-        BoxScale = 1.0f;
+        BoxScale = ImPlot3DPoint(1.0f, 1.0f, 1.0f);
         AnimationTime = 0.0f;
         RotationAnimationEnd = Rotation;
         SetupLocked = false;

--- a/implot3d_internal.h
+++ b/implot3d_internal.h
@@ -521,9 +521,10 @@ struct ImPlot3DPlot {
     ImRect FrameRect;  // Outermost bounding rectangle that encapsulates whole the plot/title/padding/etc
     ImRect CanvasRect; // Frame rectangle reduced by padding
     ImRect PlotRect;   // Bounding rectangle for the actual plot area
-    // Rotation & Axes
-    ImPlot3DQuat Rotation;
-    ImPlot3DAxis Axes[3];
+    // Plot box state
+    ImPlot3DQuat Rotation;   // Current rotation quaternion
+    ImPlot3DAxis Axes[3];    // X, Y, Z axes
+    ImPlot3DPoint BoxAspect; // Aspect ratio of the plot box
     // Animation
     float AnimationTime;               // Remaining animation time
     ImPlot3DQuat RotationAnimationEnd; // End rotation for animation
@@ -551,6 +552,7 @@ struct ImPlot3DPlot {
         Rotation = ImPlot3DQuat(0.0f, 0.0f, 0.0f, 1.0f);
         for (int i = 0; i < 3; i++)
             Axes[i] = ImPlot3DAxis();
+        BoxAspect = ImPlot3DPoint(1.0f, 1.0f, 1.0f);
         AnimationTime = 0.0f;
         RotationAnimationEnd = Rotation;
         SetupLocked = false;

--- a/implot3d_internal.h
+++ b/implot3d_internal.h
@@ -505,8 +505,6 @@ struct ImPlot3DAxis {
     bool IsAutoFitting() const;
     void ExtendFit(float value);
     void ApplyFit();
-    float PlotToNDC(float value) const;
-    float NDCToPlot(float value) const;
 };
 
 // Holds plot state information that must persist after EndPlot


### PR DESCRIPTION
This PR implements the custom aspect ratio proposed in #15 and #24

The plot box can now be scaled using the context menu (right-click), or programmatically.

## Change with context menu
Here is an example of changing the box scale using the context menu.

https://github.com/user-attachments/assets/7147ba26-0c5e-4406-bb65-20b4eb253e46

## Change with code
And here is the new demo demonstrating how to do it through code (from `implot3d_demo.cpp`).

https://github.com/user-attachments/assets/e20dfdfe-b461-4254-9c12-f187138edb8e

The demo code:

```c++
void DemoBoxScale() {
    constexpr int N = 100;
    float xs[N], ys[N], zs[N];
    for (int i = 0; i < N; ++i) {
        float t = i / (float)(N - 1);
        xs[i] = sinf(t * 2.0f * IM_PI);
        ys[i] = cosf(t * 4.0f * IM_PI);
        zs[i] = t * 2.0f - 1.0f;
    }

    static float scale[3] = {1.0f, 1.0f, 1.0f};
    ImGui::SliderFloat3("Box Scale", scale, 0.1f, 2.0f, "%.2f");

    if (ImPlot3D::BeginPlot("##BoxScale")) {
        ImPlot3D::SetupBoxScale(scale[0], scale[1], scale[2]);
        ImPlot3D::PlotLine("3D Curve", xs, ys, zs, N);
        ImPlot3D::EndPlot();
    }
}
```

## Other changes
- Added `IMPLOT_DISABLE_OBSOLETE_FUNCTIONS` to `implot3d.cpp` and `implot3d_demo.cpp` to avoid using deprecated ImGui API
- Improved `Locator_Default` to change the grid depending on the plot box scale
