### PR TITLE
Fix warnings & README bindings

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Configure
         run: |
           cd example
-          cmake -B build -DCMAKE_CXX_COMPILER=${{ matrix.compiler }} -DCMAKE_CXX_FLAGS="-Werror"
+          cmake -B build -DCMAKE_CXX_COMPILER=${{ matrix.compiler }} -DCMAKE_CXX_FLAGS="-Wall -Werror"
       - name: Build
         run: |
           cd example

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Configure
         run: |
           cd example
-          cmake -B build -DCMAKE_CXX_COMPILER=${{ matrix.compiler }}
+          cmake -B build -DCMAKE_CXX_COMPILER=${{ matrix.compiler }} -DCMAKE_CXX_FLAGS="-Werror"
       - name: Build
         run: |
           cd example

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -11,5 +11,5 @@ jobs:
       - name: Build
         run: |
           cd example
-          cmake -B build
+          cmake -B build -DCMAKE_CXX_FLAGS="-Werror"
           cmake --build build

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -11,5 +11,5 @@ jobs:
       - name: Build
         run: |
           cd example
-          cmake -B build -DCMAKE_CXX_FLAGS="-Werror"
+          cmake -B build -DCMAKE_CXX_FLAGS="-Wall -Werror"
           cmake --build build

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -11,5 +11,5 @@ jobs:
       - name: Build
         run: |
           cd example
-          cmake -B build -DCMAKE_CXX_FLAGS="/WX"
+          cmake -B build -DCMAKE_CXX_FLAGS="/WX /EHsc"
           cmake --build build

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -11,5 +11,5 @@ jobs:
       - name: Build
         run: |
           cd example
-          cmake -B build
+          cmake -B build -DCMAKE_CXX_FLAGS="/WX"
           cmake --build build

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -11,5 +11,5 @@ jobs:
       - name: Build
         run: |
           cd example
-          cmake -B build -DCMAKE_CXX_FLAGS="/WX /EHsc"
+          cmake -B build -DCMAKE_CXX_FLAGS="/EHsc /W3 /WX"
           cmake --build build

--- a/README.md
+++ b/README.md
@@ -147,6 +147,12 @@ Not currently. You can use your OS's screen capturing tools to save a plot. ImPl
 #### Is ImPlot3D suitable for publication-quality visuals?
 ImPlot3D prioritizes interactivity and real-time performance. If you need high-quality visualizations, use ImPlot3D for initial exploration and then switch to tools like [MATLAB](https://www.mathworks.com/products/matlab.html), [matplotlib](https://matplotlib.org/), or [ParaView](https://www.paraview.org/) for the final output.
 
+#### Can I use ImPlot3D with other languages/bindings?
+Yes! ImPlot3D can be used with various languages through the following bindings:
+- **Python**: [imgui-bundle](https://pypi.org/project/imgui-bundle/)
+- **C**: [cimplot3d](https://github.com/cimgui/cimplot3d)
+- **Lua**: [LuaJIT-ImGui](https://github.com/sonoro1234/LuaJIT-ImGui)
+
 ## 🤝 Contributing
 ImPlot3D is growing quickly and I would love more people to get involved in the project. Whether you have ideas to share, bugs to report, or features to implement, your contributions are welcome!
 

--- a/implot3d_demo.cpp
+++ b/implot3d_demo.cpp
@@ -128,7 +128,7 @@ void DemoScatterPlots() {
         ImPlot3D::PlotScatter("Data 1", xs1, ys1, zs1, 100);
         ImPlot3D::PushStyleVar(ImPlot3DStyleVar_FillAlpha, 0.25f);
         ImPlot3D::SetNextMarkerStyle(ImPlot3DMarker_Square, 6, ImPlot3D::GetColormapColor(1), IMPLOT3D_AUTO, ImPlot3D::GetColormapColor(1));
-        ImPlot3D::PlotScatter("Data 2", xs2, ys2, zs1, 50);
+        ImPlot3D::PlotScatter("Data 2", xs2, ys2, zs2, 50);
         ImPlot3D::PopStyleVar();
         ImPlot3D::EndPlot();
     }

--- a/implot3d_internal.h
+++ b/implot3d_internal.h
@@ -127,7 +127,12 @@ struct ImDrawList3D {
     ImDrawListSharedData* _SharedData; // [Internal] shared draw list data
 
     ImDrawList3D() {
-        memset(this, 0, sizeof(*this));
+        _VtxCurrentIdx = 0;
+        _VtxWritePtr = nullptr;
+        _IdxWritePtr = nullptr;
+        _ZWritePtr = nullptr;
+        _Flags = ImDrawListFlags_None;
+        _SharedData = nullptr;
     }
 
     void PrimReserve(int idx_count, int vtx_count);

--- a/implot3d_items.cpp
+++ b/implot3d_items.cpp
@@ -266,8 +266,8 @@ void SetNextLineStyle(const ImVec4& col, float weight) {
 void SetNextFillStyle(const ImVec4& col, float alpha) {
     ImPlot3DContext& gp = *GImPlot3D;
     ImPlot3DNextItemData& n = gp.NextItemData;
-    gp.NextItemData.Colors[ImPlot3DCol_Fill] = col;
-    gp.NextItemData.FillAlpha = alpha;
+    n.Colors[ImPlot3DCol_Fill] = col;
+    n.FillAlpha = alpha;
 }
 
 void SetNextMarkerStyle(ImPlot3DMarker marker, float size, const ImVec4& fill, float weight, const ImVec4& outline) {
@@ -747,8 +747,8 @@ struct RendererSurfaceFill : RendererBase {
             float min = Min;
             float max = Max;
             if (ScaleMin != 0.0 || ScaleMax != 0.0) {
-                min = ScaleMin;
-                max = ScaleMax;
+                min = (float)ScaleMin;
+                max = (float)ScaleMax;
             }
             for (int i = 0; i < 4; i++) {
                 ImVec4 col = SampleColormap(ImClamp(ImRemap01(p_plot[i].z, min, max), 0.0f, 1.0f));


### PR DESCRIPTION
This PR introduces an update in the workflows to make sure the CD/CI fails if there are warnings. This is needed to avoid introducing new warnings as found in #52

The README was also updated to include information about the python/c/lua bindings