### PR TITLE
Fix min/max lock & axis transformation

### DIFF
--- a/implot3d.cpp
+++ b/implot3d.cpp
@@ -1861,7 +1861,8 @@ void HandleInput(ImPlot3DPlot& plot) {
             // Adjust plot range to translate the plot
             for (int i = 0; i < 3; i++) {
                 if (plot.Axes[i].Hovered) {
-                    plot.Axes[i].SetRange(plot.Axes[i].Range.Min - delta_plot[i], plot.Axes[i].Range.Max - delta_plot[i]);
+                    plot.Axes[i].SetMin(plot.Axes[i].Range.Min - delta_plot[i]);
+                    plot.Axes[i].SetMax(plot.Axes[i].Range.Max - delta_plot[i]);
                     plot.Axes[i].Held = true;
                 }
                 // If no axis was held before (user started translating in this frame), set the held edge/plane indices
@@ -1882,8 +1883,8 @@ void HandleInput(ImPlot3DPlot& plot) {
             // Apply translation to the selected axes
             for (int i = 0; i < 3; i++) {
                 if (plot.Axes[i].Hovered) {
-                    plot.Axes[i].SetRange(plot.Axes[i].Range.Min - delta_plot[i],
-                                          plot.Axes[i].Range.Max - delta_plot[i]);
+                    plot.Axes[i].SetMin(plot.Axes[i].Range.Min - delta_plot[i]);
+                    plot.Axes[i].SetMax(plot.Axes[i].Range.Max - delta_plot[i]);
                     plot.Axes[i].Held = true;
                 }
                 if (!any_axis_held) {
@@ -2011,7 +2012,8 @@ void HandleInput(ImPlot3DPlot& plot) {
 
             // Set new range after zoom
             if (plot.Axes[i].Hovered) {
-                plot.Axes[i].SetRange(new_min, new_max);
+                plot.Axes[i].SetMin(new_min);
+                plot.Axes[i].SetMax(new_max);
                 plot.Axes[i].Held = true;
             }
 

--- a/implot3d_internal.h
+++ b/implot3d_internal.h
@@ -444,6 +444,7 @@ struct ImPlot3DAxis {
     bool FitThisFrame;
     ImPlot3DRange FitExtents;
     // User input
+    bool Hovered;
     bool Held;
 
     // Constructor
@@ -462,6 +463,7 @@ struct ImPlot3DAxis {
         FitExtents.Min = HUGE_VAL;
         FitExtents.Max = -HUGE_VAL;
         // User input
+        Hovered = false;
         Held = false;
     }
 


### PR DESCRIPTION
This PR fixes the issues found by @dimateos in #47

The fixes are:
- Axis transformation constraint would be ignored when more than one plot was visible
- Min/max axis lock was not working (the user could always move the axis range around as if it was not locked)
- The plot would giggle when the user tries to move locked axes