### PR TITLE
Add SetupAxisTicks for configuring custom ticks

### DIFF
--- a/implot3d.cpp
+++ b/implot3d.cpp
@@ -598,11 +598,11 @@ void RenderGrid(ImDrawList* draw_list, const ImPlot3DPlot& plot, const ImPlot3DP
                 // Compute position along u
                 float t_u = (tick.PlotPos - axis_u.Range.Min) / (axis_u.Range.Max - axis_u.Range.Min);
 
-		// Skip ticks that are out of range
-		if (t_u < 0.0f || t_u > 1.0f)
-		  continue;
+                // Skip ticks that are out of range
+                if (t_u < 0.0f || t_u > 1.0f)
+                    continue;
 
-		ImPlot3DPoint p_start = p0 + u_vec * t_u;
+                ImPlot3DPoint p_start = p0 + u_vec * t_u;
                 ImPlot3DPoint p_end = p3 + u_vec * t_u;
 
                 // Convert to pixel coordinates
@@ -624,11 +624,11 @@ void RenderGrid(ImDrawList* draw_list, const ImPlot3DPlot& plot, const ImPlot3DP
                 // Compute position along v
                 float t_v = (tick.PlotPos - axis_v.Range.Min) / (axis_v.Range.Max - axis_v.Range.Min);
 
-		// Skip ticks that are out of range
-		if (t_v < 0.0f || t_v > 1.0f)
-		  continue;
+                // Skip ticks that are out of range
+                if (t_v < 0.0f || t_v > 1.0f)
+                    continue;
 
-		ImPlot3DPoint p_start = p0 + v_vec * t_v;
+                ImPlot3DPoint p_start = p0 + v_vec * t_v;
                 ImPlot3DPoint p_end = p1 + v_vec * t_v;
 
                 // Convert to pixel coordinates
@@ -730,9 +730,9 @@ void RenderTickMarks(ImDrawList* draw_list, const ImPlot3DPlot& plot, const ImPl
             const ImPlot3DTick& tick = axis.Ticker.Ticks[t];
             float v = (tick.PlotPos - axis.Range.Min) / (axis.Range.Max - axis.Range.Min);
 
-	    // Skip ticks that are out of range
-	    if (v < 0.0f || v > 1.0f)
-	      continue;
+            // Skip ticks that are out of range
+            if (v < 0.0f || v > 1.0f)
+                continue;
             ImPlot3DPoint tick_pos_ndc = PlotToNDC(axis_start + axis_dir * (v * axis_len));
 
             // Half tick on each side of the axis line
@@ -825,10 +825,10 @@ void RenderTickLabels(ImDrawList* draw_list, const ImPlot3DPlot& plot, const ImP
             // Compute position along the axis
             float t_axis = (tick.PlotPos - axis.Range.Min) / (axis.Range.Max - axis.Range.Min);
 
-	    // Skip ticks that are out of range
-	    if (t_axis < 0.0f || t_axis > 1.0f)
-	      continue;
-	    ImPlot3DPoint tick_pos = axis_start + axis_dir * t_axis;
+            // Skip ticks that are out of range
+            if (t_axis < 0.0f || t_axis > 1.0f)
+                continue;
+            ImPlot3DPoint tick_pos = axis_start + axis_dir * t_axis;
 
             // Convert to pixel coordinates
             ImVec2 tick_pos_pix = PlotToPixels(tick_pos);
@@ -1505,16 +1505,16 @@ void SetupAxisFormat(ImAxis3D idx, ImPlot3DFormatter formatter, void* data) {
 void SetupAxisTicks(ImAxis3D idx, const double* values, int n_ticks, const char* const labels[]) {
     ImPlot3DContext& gp = *GImPlot3D;
     IM_ASSERT_USER_ERROR(gp.CurrentPlot != nullptr && !gp.CurrentPlot->SetupLocked,
-			 "Setup needs to be called after BeginPlot and before any setup locking functions (e.g. PlotX)!");
+                         "Setup needs to be called after BeginPlot and before any setup locking functions (e.g. PlotX)!");
     ImPlot3DPlot& plot = *gp.CurrentPlot;
     ImPlot3DAxis& axis = plot.Axes[idx];
     axis.ShowDefaultTicks = false;
     AddTicksCustom(values,
-		   labels,
-		   n_ticks,
-		   axis.Ticker,
-		   axis.Formatter ? axis.Formatter : Formatter_Default,
-		   (axis.Formatter && axis.FormatterData) ? axis.FormatterData  : (void*)IMPLOT3D_LABEL_FORMAT);
+                   labels,
+                   n_ticks,
+                   axis.Ticker,
+                   axis.Formatter ? axis.Formatter : Formatter_Default,
+                   (axis.Formatter && axis.FormatterData) ? axis.FormatterData : (void*)IMPLOT3D_LABEL_FORMAT);
 }
 
 void SetupAxes(const char* x_label, const char* y_label, const char* z_label, ImPlot3DAxisFlags x_flags, ImPlot3DAxisFlags y_flags, ImPlot3DAxisFlags z_flags) {
@@ -2143,10 +2143,10 @@ void SetupLock() {
     // Compute ticks
     for (int i = 0; i < 3; i++) {
         ImPlot3DAxis& axis = plot.Axes[i];
-	if (axis.ShowDefaultTicks) {
-	  float pixels = plot.GetBoxZoom() * plot.BoxScale[i];
-	  axis.Locator(axis.Ticker, axis.Range, pixels, axis.Formatter, axis.FormatterData);
-	}
+        if (axis.ShowDefaultTicks) {
+            float pixels = plot.GetBoxZoom() * plot.BoxScale[i];
+            axis.Locator(axis.Ticker, axis.Range, pixels, axis.Formatter, axis.FormatterData);
+        }
     }
 
     // Render title

--- a/implot3d.cpp
+++ b/implot3d.cpp
@@ -1502,13 +1502,13 @@ void SetupAxisFormat(ImAxis3D idx, ImPlot3DFormatter formatter, void* data) {
     axis.FormatterData = data;
 }
 
-void SetupAxisTicks(ImAxis3D idx, const double* values, int n_ticks, const char* const labels[]) {
+void SetupAxisTicks(ImAxis3D idx, const double* values, int n_ticks, const char* const labels[], bool keep_default) {
     ImPlot3DContext& gp = *GImPlot3D;
     IM_ASSERT_USER_ERROR(gp.CurrentPlot != nullptr && !gp.CurrentPlot->SetupLocked,
                          "Setup needs to be called after BeginPlot and before any setup locking functions (e.g. PlotX)!");
     ImPlot3DPlot& plot = *gp.CurrentPlot;
     ImPlot3DAxis& axis = plot.Axes[idx];
-    axis.ShowDefaultTicks = false;
+    axis.ShowDefaultTicks = keep_default;
     AddTicksCustom(values,
                    labels,
                    n_ticks,

--- a/implot3d.cpp
+++ b/implot3d.cpp
@@ -1522,8 +1522,9 @@ void SetupAxisTicks(ImAxis3D idx, double v_min, double v_max, int n_ticks, const
     IM_ASSERT_USER_ERROR(gp.CurrentPlot != nullptr && !gp.CurrentPlot->SetupLocked,
                          "Setup needs to be called after BeginPlot and before any setup locking functions (e.g. PlotX)!");
     n_ticks = n_ticks < 2 ? 2 : n_ticks;
-    FillRange(gp.TempDouble1, n_ticks, v_min, v_max);
-    SetupAxisTicks(idx, gp.TempDouble1.Data, n_ticks, labels, keep_default);
+    ImVector<double> temp;
+    FillRange(temp, n_ticks, v_min, v_max);
+    SetupAxisTicks(idx, temp.Data, n_ticks, labels, keep_default);
 }
 
 void SetupAxes(const char* x_label, const char* y_label, const char* z_label, ImPlot3DAxisFlags x_flags, ImPlot3DAxisFlags y_flags, ImPlot3DAxisFlags z_flags) {

--- a/implot3d.cpp
+++ b/implot3d.cpp
@@ -1517,6 +1517,15 @@ void SetupAxisTicks(ImAxis3D idx, const double* values, int n_ticks, const char*
                    (axis.Formatter && axis.FormatterData) ? axis.FormatterData : (void*)IMPLOT3D_LABEL_FORMAT);
 }
 
+void SetupAxisTicks(ImAxis3D idx, double v_min, double v_max, int n_ticks, const char* const labels[], bool keep_default) {
+    ImPlot3DContext& gp = *GImPlot3D;
+    IM_ASSERT_USER_ERROR(gp.CurrentPlot != nullptr && !gp.CurrentPlot->SetupLocked,
+                         "Setup needs to be called after BeginPlot and before any setup locking functions (e.g. PlotX)!");
+    n_ticks = n_ticks < 2 ? 2 : n_ticks;
+    FillRange(gp.TempDouble1, n_ticks, v_min, v_max);
+    SetupAxisTicks(idx, gp.TempDouble1.Data, n_ticks, labels, keep_default);
+}
+
 void SetupAxes(const char* x_label, const char* y_label, const char* z_label, ImPlot3DAxisFlags x_flags, ImPlot3DAxisFlags y_flags, ImPlot3DAxisFlags z_flags) {
     SetupAxis(ImAxis3D_X, x_label, x_flags);
     SetupAxis(ImAxis3D_Y, y_label, y_flags);

--- a/implot3d.h
+++ b/implot3d.h
@@ -364,7 +364,11 @@ IMPLOT3D_API void SetupAxisLimits(ImAxis3D axis, double v_min, double v_max, ImP
 
 IMPLOT3D_API void SetupAxisFormat(ImAxis3D idx, ImPlot3DFormatter formatter, void* data = nullptr);
 
+// Sets an axis' ticks and optionally the labels. To keep the default ticks, set #keep_default=true.
 IMPLOT3D_API void SetupAxisTicks(ImAxis3D axis, const double* values, int n_ticks, const char* const labels[] = nullptr, bool keep_default = false);
+
+// Sets an axis' ticks and optionally the labels for the next plot. To keep the default ticks, set #keep_default=true.
+IMPLOT3D_API void SetupAxisTicks(ImAxis3D axis, double v_min, double v_max, int n_ticks, const char* const labels[] = nullptr, bool keep_default = false);
 
 // Sets the label and/or flags for primary X/Y/Z axes (shorthand for three calls to SetupAxis)
 IMPLOT3D_API void SetupAxes(const char* x_label, const char* y_label, const char* z_label, ImPlot3DAxisFlags x_flags = 0, ImPlot3DAxisFlags y_flags = 0, ImPlot3DAxisFlags z_flags = 0);

--- a/implot3d.h
+++ b/implot3d.h
@@ -364,7 +364,7 @@ IMPLOT3D_API void SetupAxisLimits(ImAxis3D axis, double v_min, double v_max, ImP
 
 IMPLOT3D_API void SetupAxisFormat(ImAxis3D idx, ImPlot3DFormatter formatter, void* data = nullptr);
 
-IMPLOT3D_API void SetupAxisTicks(ImAxis3D axis, const double* values, int n_ticks, const char* const labels[] = nullptr);
+IMPLOT3D_API void SetupAxisTicks(ImAxis3D axis, const double* values, int n_ticks, const char* const labels[] = nullptr, bool keep_default = false);
 
 // Sets the label and/or flags for primary X/Y/Z axes (shorthand for three calls to SetupAxis)
 IMPLOT3D_API void SetupAxes(const char* x_label, const char* y_label, const char* z_label, ImPlot3DAxisFlags x_flags = 0, ImPlot3DAxisFlags y_flags = 0, ImPlot3DAxisFlags z_flags = 0);

--- a/implot3d.h
+++ b/implot3d.h
@@ -364,7 +364,7 @@ IMPLOT3D_API void SetupAxisLimits(ImAxis3D axis, double v_min, double v_max, ImP
 
 IMPLOT3D_API void SetupAxisFormat(ImAxis3D idx, ImPlot3DFormatter formatter, void* data = nullptr);
 
-IMPLOT3D_API void SetupAxisTicks(ImAxis3D axis, const double* values, int n_ticks, const char* const labels[]=nullptr);
+IMPLOT3D_API void SetupAxisTicks(ImAxis3D axis, const double* values, int n_ticks, const char* const labels[] = nullptr);
 
 // Sets the label and/or flags for primary X/Y/Z axes (shorthand for three calls to SetupAxis)
 IMPLOT3D_API void SetupAxes(const char* x_label, const char* y_label, const char* z_label, ImPlot3DAxisFlags x_flags = 0, ImPlot3DAxisFlags y_flags = 0, ImPlot3DAxisFlags z_flags = 0);

--- a/implot3d.h
+++ b/implot3d.h
@@ -364,10 +364,10 @@ IMPLOT3D_API void SetupAxisLimits(ImAxis3D axis, double v_min, double v_max, ImP
 
 IMPLOT3D_API void SetupAxisFormat(ImAxis3D idx, ImPlot3DFormatter formatter, void* data = nullptr);
 
-// Sets an axis' ticks and optionally the labels. To keep the default ticks, set #keep_default=true.
+// Sets an axis' ticks and optionally the labels. To keep the default ticks, set #keep_default=true
 IMPLOT3D_API void SetupAxisTicks(ImAxis3D axis, const double* values, int n_ticks, const char* const labels[] = nullptr, bool keep_default = false);
 
-// Sets an axis' ticks and optionally the labels for the next plot. To keep the default ticks, set #keep_default=true.
+// Sets an axis' ticks and optionally the labels for the next plot. To keep the default ticks, set #keep_default=true
 IMPLOT3D_API void SetupAxisTicks(ImAxis3D axis, double v_min, double v_max, int n_ticks, const char* const labels[] = nullptr, bool keep_default = false);
 
 // Sets the label and/or flags for primary X/Y/Z axes (shorthand for three calls to SetupAxis)

--- a/implot3d.h
+++ b/implot3d.h
@@ -364,6 +364,8 @@ IMPLOT3D_API void SetupAxisLimits(ImAxis3D axis, double v_min, double v_max, ImP
 
 IMPLOT3D_API void SetupAxisFormat(ImAxis3D idx, ImPlot3DFormatter formatter, void* data = nullptr);
 
+IMPLOT3D_API void SetupAxisTicks(ImAxis3D axis, const double* values, int n_ticks, const char* const labels[]=nullptr);
+
 // Sets the label and/or flags for primary X/Y/Z axes (shorthand for three calls to SetupAxis)
 IMPLOT3D_API void SetupAxes(const char* x_label, const char* y_label, const char* z_label, ImPlot3DAxisFlags x_flags = 0, ImPlot3DAxisFlags y_flags = 0, ImPlot3DAxisFlags z_flags = 0);
 

--- a/implot3d_demo.cpp
+++ b/implot3d_demo.cpp
@@ -565,6 +565,31 @@ void DemoBoxScale() {
     }
 }
 
+void DemoTickLabels() {
+    static bool custom_ticks = false;
+    static bool custom_labels = true;
+    ImGui::Checkbox("Show Custom Ticks", &custom_ticks);
+    if (custom_ticks) {
+        ImGui::SameLine();
+        ImGui::Checkbox("Show Custom Labels", &custom_labels);
+    }
+    const double pi = 3.14;
+    const char* pi_str[] = {"PI"};
+    static double yticks[] = {100, 300, 700, 900};
+    static const char* ylabels[] = {"One", "Three", "Seven", "Nine"};
+    static double zticks[] = {0.0, 0.2, 0.4, 0.6, 0.8, 1.0};
+    static const char* zlabels[] = {"A", "B", "C", "D", "E", "F"};
+    if (ImPlot3D::BeginPlot("##Ticks")) {
+        ImPlot3D::SetupAxesLimits(3, 5, 0, 1000, 0, 1);
+        if (custom_ticks) {
+            ImPlot3D::SetupAxisTicks(ImAxis3D_X, &pi, 1, custom_labels ? pi_str : nullptr, true);
+            ImPlot3D::SetupAxisTicks(ImAxis3D_Y, yticks, 4, custom_labels ? ylabels : nullptr, false);
+            ImPlot3D::SetupAxisTicks(ImAxis3D_Z, zticks, 6, custom_labels ? zlabels : nullptr, false);
+        }
+        ImPlot3D::EndPlot();
+    }
+}
+
 //-----------------------------------------------------------------------------
 // [SECTION] Custom
 //-----------------------------------------------------------------------------
@@ -753,6 +778,7 @@ void ShowDemoWindow(bool* p_open) {
         }
         if (ImGui::BeginTabItem("Axes")) {
             DemoHeader("Box Scale", DemoBoxScale);
+            DemoHeader("Tick Labels", DemoTickLabels);
             ImGui::EndTabItem();
         }
         if (ImGui::BeginTabItem("Custom")) {

--- a/implot3d_demo.cpp
+++ b/implot3d_demo.cpp
@@ -575,16 +575,14 @@ void DemoTickLabels() {
     }
     const double pi = 3.14;
     const char* pi_str[] = {"PI"};
-    static double yticks[] = {100, 300, 700, 900};
-    static const char* ylabels[] = {"One", "Three", "Seven", "Nine"};
-    static double zticks[] = {0.0, 0.2, 0.4, 0.6, 0.8, 1.0};
-    static const char* zlabels[] = {"A", "B", "C", "D", "E", "F"};
+    static double letters_ticks[] = {0.0, 0.2, 0.4, 0.6, 0.8, 1.0};
+    static const char* letters_labels[] = {"A", "B", "C", "D", "E", "F"};
     if (ImPlot3D::BeginPlot("##Ticks")) {
-        ImPlot3D::SetupAxesLimits(3, 5, 0, 1000, 0, 1);
+        ImPlot3D::SetupAxesLimits(2, 5, 0, 1, 0, 1);
         if (custom_ticks) {
             ImPlot3D::SetupAxisTicks(ImAxis3D_X, &pi, 1, custom_labels ? pi_str : nullptr, true);
-            ImPlot3D::SetupAxisTicks(ImAxis3D_Y, yticks, 4, custom_labels ? ylabels : nullptr, false);
-            ImPlot3D::SetupAxisTicks(ImAxis3D_Z, zticks, 6, custom_labels ? zlabels : nullptr, false);
+            ImPlot3D::SetupAxisTicks(ImAxis3D_Y, letters_ticks, 6, custom_labels ? letters_labels : nullptr, false);
+            ImPlot3D::SetupAxisTicks(ImAxis3D_Z, 0, 1, 6, custom_labels ? letters_labels : nullptr, false);
         }
         ImPlot3D::EndPlot();
     }

--- a/implot3d_internal.h
+++ b/implot3d_internal.h
@@ -611,9 +611,6 @@ struct ImPlot3DContext {
     ImVector<ImGuiStyleMod> StyleModifiers;
     ImVector<ImPlot3DColormap> ColormapModifiers;
     ImPlot3DColormapData ColormapData;
-
-    // Temp data for general use
-    ImVector<double> TempDouble1, TempDouble2;
 };
 
 //-----------------------------------------------------------------------------

--- a/implot3d_internal.h
+++ b/implot3d_internal.h
@@ -97,6 +97,16 @@ static inline ImU32 ImMixU32(ImU32 a, ImU32 b, ImU32 s) {
 #endif
 }
 
+// Fills a buffer with n samples linear interpolated from vmin to vmax
+template <typename T>
+void FillRange(ImVector<T>& buffer, int n, T vmin, T vmax) {
+    buffer.resize(n);
+    T step = (vmax - vmin) / (n - 1);
+    for (int i = 0; i < n; ++i) {
+        buffer[i] = vmin + i * step;
+    }
+}
+
 } // namespace ImPlot3D
 
 //-----------------------------------------------------------------------------
@@ -601,6 +611,9 @@ struct ImPlot3DContext {
     ImVector<ImGuiStyleMod> StyleModifiers;
     ImVector<ImPlot3DColormap> ColormapModifiers;
     ImPlot3DColormapData ColormapData;
+
+    // Temp data for general use
+    ImVector<double> TempDouble1, TempDouble2;
 };
 
 //-----------------------------------------------------------------------------

--- a/implot3d_internal.h
+++ b/implot3d_internal.h
@@ -453,7 +453,7 @@ struct ImPlot3DAxis {
         Formatter = nullptr;
         FormatterData = nullptr;
         Locator = nullptr;
-	ShowDefaultTicks = true;
+        ShowDefaultTicks = true;
         // Fit data
         FitThisFrame = true;
         FitExtents.Min = HUGE_VAL;
@@ -469,7 +469,7 @@ struct ImPlot3DAxis {
         ShowDefaultTicks = true;
         FitExtents.Min = HUGE_VAL;
         FitExtents.Max = -HUGE_VAL;
-	Ticker.Reset();
+        Ticker.Reset();
     }
 
     inline void SetRange(double v1, double v2) {

--- a/implot3d_internal.h
+++ b/implot3d_internal.h
@@ -435,6 +435,7 @@ struct ImPlot3DAxis {
     ImPlot3DFormatter Formatter;
     void* FormatterData;
     ImPlot3DLocator Locator;
+    bool ShowDefaultTicks;
     // Fit data
     bool FitThisFrame;
     ImPlot3DRange FitExtents;
@@ -452,12 +453,23 @@ struct ImPlot3DAxis {
         Formatter = nullptr;
         FormatterData = nullptr;
         Locator = nullptr;
+	ShowDefaultTicks = true;
         // Fit data
         FitThisFrame = true;
         FitExtents.Min = HUGE_VAL;
         FitExtents.Max = -HUGE_VAL;
         // User input
         Held = false;
+    }
+
+    inline void Reset() {
+        Formatter = nullptr;
+        FormatterData = nullptr;
+        Locator = nullptr;
+        ShowDefaultTicks = true;
+        FitExtents.Min = HUGE_VAL;
+        FitExtents.Max = -HUGE_VAL;
+	Ticker.Reset();
     }
 
     inline void SetRange(double v1, double v2) {


### PR DESCRIPTION
Add SetupAxisTicks to ImPlot3D

This pull request introduces the `SetupAxisTicks` feature to ImPlot3D, bringing functionality similar to ImPlot's implementation. Key changes and improvements include:

**1. Addition of `SetupAxisTicks`:**
        A new function SetupAxisTicks has been implemented for ImPlot3D, closely mirroring the behavior in ImPlot.
        The only exception is the handling of the `ShowDefaultTicks` boolean, which is automatically set when using SetupAxisTicks. Future updates could expand its configurability if needed.

**2. Axis Reset Refactoring:**
        The axis reset logic has been moved into `BeginPlot` for better initialization and consistency.
        A `Reset()` method has been added to the axis struct, making it easier to manage axis state during plot setup.

**3. Custom Tick Rendering Improvements:**
        Added checks in the rendering logic for grid lines, tick markers, and tick labels to ensure that custom ticks outside the axis range are not rendered. This ensures proper handling and prevents visual inconsistencies.