### PR TITLE
Add an integer encoded version number (`IMPLOT3D_VERSION_NUM`)

### DIFF
--- a/implot3d.h
+++ b/implot3d.h
@@ -46,6 +46,7 @@
 #endif
 
 #define IMPLOT3D_VERSION "0.2"                // ImPlot3D version
+#define IMPLOT3D_VERSION_NUM 200              // Integer encoded version
 #define IMPLOT3D_AUTO -1                      // Deduce variable automatically
 #define IMPLOT3D_AUTO_COL ImVec4(0, 0, 0, -1) // Deduce color automatically
 #define IMPLOT3D_TMP template <typename T> IMPLOT3D_API


### PR DESCRIPTION
This PR adds an integer encoded version macro (`IMPLOT3D_VERSION_NUM`) like in the original Dear ImGui library. 
It is necessary to allow for preprocessor conditionals (`#if IMPLOT3D_VERSION_NUM > 200`) and better integration into other codebases.