### PR TITLE
Fix division by zero in ImRemap01 function

### DIFF
--- a/implot3d_internal.h
+++ b/implot3d_internal.h
@@ -59,7 +59,7 @@ static inline bool ImHasFlag(TSet set, TFlag flag) { return (set & flag) == flag
 template <typename TSet, typename TFlag>
 static inline void ImFlipFlag(TSet& set, TFlag flag) { ImHasFlag(set, flag) ? set &= ~flag : set |= flag; }
 template <typename T>
-static inline T ImRemap01(T x, T x0, T x1) { return (x - x0) / (x1 - x0); }
+static inline T ImRemap01(T x, T x0, T x1) { return (x1 - x0) ? ((x - x0) / (x1 - x0)) : 0; }
 // Returns true if val is NAN
 static inline bool ImNan(float val) { return isnan(val); }
 // Returns true if val is NAN or INFINITY


### PR DESCRIPTION
This PR fixes a division by zero issue in `ImRemap01`, which was causing exceptions when all Z values were identical.
The updated function now checks if `(x1 - x0) == 0` before performing the division.

Fixes #74 