### PR TITLE
AddTextRotated: fix for incoming ImGui v1.92

### DIFF
--- a/implot3d.cpp
+++ b/implot3d.cpp
@@ -107,10 +107,15 @@ void AddTextRotated(ImDrawList* draw_list, ImVec2 pos, float angle, ImU32 col, c
     ImGuiContext& g = *GImGui;
     ImFont* font = g.Font;
 
+#ifdef IMGUI_HAS_TEXTURES
+    ImFontBaked* fontBaked = g.Font->GetFontBaked(g.FontSize);
+    const float scale = g.FontSize / fontBaked->Size;
+#else
+    const float scale = g.FontSize / font->FontSize;
+#endif
+
     // Align to be pixel perfect
     pos = ImFloor(pos);
-
-    const float scale = g.FontSize / font->FontSize;
 
     // Measure the size of the text in unrotated coordinates
     ImVec2 text_size = font->CalcTextSizeA(g.FontSize, FLT_MAX, 0.0f, text_begin, text_end, nullptr);
@@ -139,7 +144,11 @@ void AddTextRotated(ImDrawList* draw_list, ImVec2 pos, float angle, ImU32 col, c
                 break;
         }
 
+#ifdef IMGUI_HAS_TEXTURES
+        const ImFontGlyph* glyph = fontBaked->FindGlyph((ImWchar)c);
+#else
         const ImFontGlyph* glyph = font->FindGlyph((ImWchar)c);
+#endif
         if (glyph == nullptr) {
             continue;
         }


### PR DESCRIPTION
 Hi,

This PR proposes a fix to AddTextRotated, to account for an incoming change in the API documented at 

https://github.com/ocornut/imgui/issues/8465

This change is inspired by a similar change recently authored by @ocornut in ImPlot: 
https://github.com/epezent/implot/commit/193b9d8f92c4a437e84182b171f1ae266e72321f

