### PR TITLE
Perf: Flags to plot without lines/fill/markers

### DIFF
--- a/implot3d.h
+++ b/implot3d.h
@@ -217,6 +217,9 @@ enum ImPlot3DSurfaceFlags_ {
     ImPlot3DSurfaceFlags_None = 0, // Default
     ImPlot3DSurfaceFlags_NoLegend = ImPlot3DItemFlags_NoLegend,
     ImPlot3DSurfaceFlags_NoFit = ImPlot3DItemFlags_NoFit,
+    ImPlot3DSurfaceFlags_NoLines = 1 << 10,   // No lines will be rendered
+    ImPlot3DSurfaceFlags_NoFill = 1 << 11,    // No fill will be rendered
+    ImPlot3DSurfaceFlags_NoMarkers = 1 << 12, // No markers will be rendered
 };
 
 // Flags for PlotMesh

--- a/implot3d.h
+++ b/implot3d.h
@@ -227,6 +227,9 @@ enum ImPlot3DMeshFlags_ {
     ImPlot3DMeshFlags_None = 0, // Default
     ImPlot3DMeshFlags_NoLegend = ImPlot3DItemFlags_NoLegend,
     ImPlot3DMeshFlags_NoFit = ImPlot3DItemFlags_NoFit,
+    ImPlot3DMeshFlags_NoLines = 1 << 10,   // No lines will be rendered
+    ImPlot3DMeshFlags_NoFill = 1 << 11,    // No fill will be rendered
+    ImPlot3DMeshFlags_NoMarkers = 1 << 12, // No markers will be rendered
 };
 
 // Flags for PlotImage

--- a/implot3d.h
+++ b/implot3d.h
@@ -203,6 +203,9 @@ enum ImPlot3DTriangleFlags_ {
     ImPlot3DTriangleFlags_None = 0, // Default
     ImPlot3DTriangleFlags_NoLegend = ImPlot3DItemFlags_NoLegend,
     ImPlot3DTriangleFlags_NoFit = ImPlot3DItemFlags_NoFit,
+    ImPlot3DTriangleFlags_NoLines = 1 << 10,   // No lines will be rendered
+    ImPlot3DTriangleFlags_NoFill = 1 << 11,    // No fill will be rendered
+    ImPlot3DTriangleFlags_NoMarkers = 1 << 12, // No markers will be rendered
 };
 
 // Flags for PlotQuad

--- a/implot3d.h
+++ b/implot3d.h
@@ -213,6 +213,9 @@ enum ImPlot3DQuadFlags_ {
     ImPlot3DQuadFlags_None = 0, // Default
     ImPlot3DQuadFlags_NoLegend = ImPlot3DItemFlags_NoLegend,
     ImPlot3DQuadFlags_NoFit = ImPlot3DItemFlags_NoFit,
+    ImPlot3DQuadFlags_NoLines = 1 << 10,   // No lines will be rendered
+    ImPlot3DQuadFlags_NoFill = 1 << 11,    // No fill will be rendered
+    ImPlot3DQuadFlags_NoMarkers = 1 << 12, // No markers will be rendered
 };
 
 // Flags for PlotSurface

--- a/implot3d_demo.cpp
+++ b/implot3d_demo.cpp
@@ -262,6 +262,12 @@ void DemoQuadPlots() {
     xs[23] = -1; ys[23] =  1; zs[23] = -1;
     // clang-format on
 
+    // Quad flags
+    static ImPlot3DQuadFlags flags = ImPlot3DQuadFlags_None;
+    CHECKBOX_FLAG(flags, ImPlot3DQuadFlags_NoLines);
+    CHECKBOX_FLAG(flags, ImPlot3DQuadFlags_NoFill);
+    CHECKBOX_FLAG(flags, ImPlot3DQuadFlags_NoMarkers);
+
     if (ImPlot3D::BeginPlot("Quad Plots")) {
         ImPlot3D::SetupAxesLimits(-1.5f, 1.5f, -1.5f, 1.5f, -1.5f, 1.5f);
 
@@ -270,21 +276,21 @@ void DemoQuadPlots() {
         ImPlot3D::SetNextFillStyle(colorX);
         ImPlot3D::SetNextLineStyle(colorX, 2);
         ImPlot3D::SetNextMarkerStyle(ImPlot3DMarker_Square, 3, colorX, IMPLOT3D_AUTO, colorX);
-        ImPlot3D::PlotQuad("X", &xs[0], &ys[0], &zs[0], 8);
+        ImPlot3D::PlotQuad("X", &xs[0], &ys[0], &zs[0], 8, flags);
 
         // Render +y and -y faces
         static ImVec4 colorY(0.2f, 0.8f, 0.2f, 0.8f); // Green
         ImPlot3D::SetNextFillStyle(colorY);
         ImPlot3D::SetNextLineStyle(colorY, 2);
         ImPlot3D::SetNextMarkerStyle(ImPlot3DMarker_Square, 3, colorY, IMPLOT3D_AUTO, colorY);
-        ImPlot3D::PlotQuad("Y", &xs[8], &ys[8], &zs[8], 8);
+        ImPlot3D::PlotQuad("Y", &xs[8], &ys[8], &zs[8], 8, flags);
 
         // Render +z and -z faces
         static ImVec4 colorZ(0.2f, 0.2f, 0.8f, 0.8f); // Blue
         ImPlot3D::SetNextFillStyle(colorZ);
         ImPlot3D::SetNextLineStyle(colorZ, 2);
         ImPlot3D::SetNextMarkerStyle(ImPlot3DMarker_Square, 3, colorZ, IMPLOT3D_AUTO, colorZ);
-        ImPlot3D::PlotQuad("Z", &xs[16], &ys[16], &zs[16], 8);
+        ImPlot3D::PlotQuad("Z", &xs[16], &ys[16], &zs[16], 8, flags);
 
         ImPlot3D::EndPlot();
     }
@@ -395,16 +401,16 @@ void DemoMeshPlots() {
     static int mesh_id = 0;
     ImGui::Combo("Mesh", &mesh_id, "Duck\0Sphere\0Cube\0\0");
 
+    // Choose line color
+    static ImVec4 line_color = ImVec4(0.5f, 0.5f, 0.2f, 0.6f);
+    ImGui::ColorEdit4("Line Color##Mesh", (float*)&line_color);
+
     // Choose fill color
     static ImVec4 fill_color = ImVec4(0.8f, 0.8f, 0.2f, 0.6f);
     ImGui::ColorEdit4("Fill Color##Mesh", (float*)&fill_color);
 
-    // Choose line color
-    static ImVec4 line_color = ImVec4(0.2f, 0.2f, 0.2f, 0.8f);
-    ImGui::ColorEdit4("Line Color##Mesh", (float*)&line_color);
-
     // Choose marker color
-    static ImVec4 marker_color = ImVec4(0.2f, 0.2f, 0.2f, 0.8f);
+    static ImVec4 marker_color = ImVec4(0.5f, 0.5f, 0.2f, 0.6f);
     ImGui::ColorEdit4("Marker Color##Mesh", (float*)&marker_color);
 
     // Mesh flags

--- a/implot3d_demo.cpp
+++ b/implot3d_demo.cpp
@@ -390,54 +390,42 @@ void DemoMeshPlots() {
     ImGui::Combo("Mesh", &mesh_id, "Duck\0Sphere\0Cube\0\0");
 
     // Choose fill color
-    static bool set_fill_color = true;
     static ImVec4 fill_color = ImVec4(0.8f, 0.8f, 0.2f, 0.6f);
-    ImGui::Checkbox("Fill Color", &set_fill_color);
-    if (set_fill_color) {
-        ImGui::SameLine();
-        ImGui::ColorEdit4("##MeshFillColor", (float*)&fill_color);
-    }
+    ImGui::ColorEdit4("Fill Color##Mesh", (float*)&fill_color);
 
     // Choose line color
-    static bool set_line_color = true;
     static ImVec4 line_color = ImVec4(0.2f, 0.2f, 0.2f, 0.8f);
-    ImGui::Checkbox("Line Color", &set_line_color);
-    if (set_line_color) {
-        ImGui::SameLine();
-        ImGui::ColorEdit4("##MeshLineColor", (float*)&line_color);
-    }
+    ImGui::ColorEdit4("Line Color##Mesh", (float*)&line_color);
 
     // Choose marker color
-    static bool set_marker_color = false;
     static ImVec4 marker_color = ImVec4(0.2f, 0.2f, 0.2f, 0.8f);
-    ImGui::Checkbox("Marker Color", &set_marker_color);
-    if (set_marker_color) {
-        ImGui::SameLine();
-        ImGui::ColorEdit4("##MeshMarkerColor", (float*)&marker_color);
-    }
+    ImGui::ColorEdit4("Marker Color##Mesh", (float*)&marker_color);
+
+    // Mesh flags
+    static ImPlot3DMeshFlags flags = ImPlot3DMeshFlags_NoMarkers;
+    CHECKBOX_FLAG(flags, ImPlot3DMeshFlags_NoFill);
+    CHECKBOX_FLAG(flags, ImPlot3DMeshFlags_NoLines);
+    CHECKBOX_FLAG(flags, ImPlot3DMeshFlags_NoMarkers);
 
     if (ImPlot3D::BeginPlot("Mesh Plots")) {
         ImPlot3D::SetupAxesLimits(-1, 1, -1, 1, -1, 1);
 
-        // Set colors
-        if (set_fill_color)
-            ImPlot3D::SetNextFillStyle(fill_color);
-        else {
-            // If not set as transparent, the fill color will be determined by the colormap
-            ImPlot3D::SetNextFillStyle(ImVec4(0.0f, 0.0f, 0.0f, 0.0f));
-        }
-        if (set_line_color)
-            ImPlot3D::SetNextLineStyle(line_color);
-        if (set_marker_color)
-            ImPlot3D::SetNextMarkerStyle(ImPlot3DMarker_Square, 3, marker_color, IMPLOT3D_AUTO, marker_color);
+        // Set fill style
+        ImPlot3D::SetNextFillStyle(fill_color);
+
+        // Set line style
+        ImPlot3D::SetNextLineStyle(line_color);
+
+        // Set marker style
+        ImPlot3D::SetNextMarkerStyle(ImPlot3DMarker_Square, 3, marker_color, IMPLOT3D_AUTO, marker_color);
 
         // Plot mesh
         if (mesh_id == 0)
-            ImPlot3D::PlotMesh("Duck", duck_vtx, duck_idx, DUCK_VTX_COUNT, DUCK_IDX_COUNT);
+            ImPlot3D::PlotMesh("Duck", duck_vtx, duck_idx, DUCK_VTX_COUNT, DUCK_IDX_COUNT, flags);
         else if (mesh_id == 1)
-            ImPlot3D::PlotMesh("Sphere", sphere_vtx, sphere_idx, SPHERE_VTX_COUNT, SPHERE_IDX_COUNT);
+            ImPlot3D::PlotMesh("Sphere", sphere_vtx, sphere_idx, SPHERE_VTX_COUNT, SPHERE_IDX_COUNT, flags);
         else if (mesh_id == 2)
-            ImPlot3D::PlotMesh("Cube", cube_vtx, cube_idx, CUBE_VTX_COUNT, CUBE_IDX_COUNT);
+            ImPlot3D::PlotMesh("Cube", cube_vtx, cube_idx, CUBE_VTX_COUNT, CUBE_IDX_COUNT, flags);
 
         ImPlot3D::EndPlot();
     }

--- a/implot3d_demo.cpp
+++ b/implot3d_demo.cpp
@@ -198,6 +198,12 @@ void DemoTrianglePlots() {
 
     // Now we have 18 vertices in xs, ys, zs forming the pyramid
 
+    // Triangle flags
+    static ImPlot3DTriangleFlags flags = ImPlot3DTriangleFlags_None;
+    CHECKBOX_FLAG(flags, ImPlot3DTriangleFlags_NoLines);
+    CHECKBOX_FLAG(flags, ImPlot3DTriangleFlags_NoFill);
+    CHECKBOX_FLAG(flags, ImPlot3DTriangleFlags_NoMarkers);
+
     if (ImPlot3D::BeginPlot("Triangle Plots")) {
         ImPlot3D::SetupAxesLimits(-1, 1, -1, 1, -0.5, 1.5);
 
@@ -207,7 +213,7 @@ void DemoTrianglePlots() {
         ImPlot3D::SetNextMarkerStyle(ImPlot3DMarker_Square, 3, ImPlot3D::GetColormapColor(2), IMPLOT3D_AUTO, ImPlot3D::GetColormapColor(2));
 
         // Plot pyramid
-        ImPlot3D::PlotTriangle("Pyramid", xs, ys, zs, 6 * 3); // 6 triangles, 3 vertices each = 18
+        ImPlot3D::PlotTriangle("Pyramid", xs, ys, zs, 6 * 3, flags); // 6 triangles, 3 vertices each = 18
         ImPlot3D::EndPlot();
     }
 }
@@ -403,8 +409,8 @@ void DemoMeshPlots() {
 
     // Mesh flags
     static ImPlot3DMeshFlags flags = ImPlot3DMeshFlags_NoMarkers;
-    CHECKBOX_FLAG(flags, ImPlot3DMeshFlags_NoFill);
     CHECKBOX_FLAG(flags, ImPlot3DMeshFlags_NoLines);
+    CHECKBOX_FLAG(flags, ImPlot3DMeshFlags_NoFill);
     CHECKBOX_FLAG(flags, ImPlot3DMeshFlags_NoMarkers);
 
     if (ImPlot3D::BeginPlot("Mesh Plots")) {

--- a/implot3d_demo.cpp
+++ b/implot3d_demo.cpp
@@ -47,6 +47,8 @@ namespace ImPlot3D {
 // [SECTION] Helpers
 //-----------------------------------------------------------------------------
 
+#define CHECKBOX_FLAG(flags, flag) ImGui::CheckboxFlags(#flag, (unsigned int*)&flags, flag)
+
 static void HelpMarker(const char* desc) {
     ImGui::TextDisabled("(?)");
     if (ImGui::BeginItemTooltip()) {
@@ -346,22 +348,34 @@ void DemoSurfacePlots() {
         ImGui::Unindent();
     }
 
+    // Select flags
+    static ImPlot3DSurfaceFlags flags = ImPlot3DSurfaceFlags_NoMarkers;
+    CHECKBOX_FLAG(flags, ImPlot3DSurfaceFlags_NoLines);
+    CHECKBOX_FLAG(flags, ImPlot3DSurfaceFlags_NoFill);
+    CHECKBOX_FLAG(flags, ImPlot3DSurfaceFlags_NoMarkers);
+
     // Begin the plot
     if (selected_fill == 1)
         ImPlot3D::PushColormap(colormaps[sel_colormap]);
     if (ImPlot3D::BeginPlot("Surface Plots", ImVec2(-1, 400), ImPlot3DFlags_NoClip)) {
-        // Set styles
         ImPlot3D::SetupAxesLimits(-1, 1, -1, 1, -1.5, 1.5);
+
+        // Set fill style
         ImPlot3D::PushStyleVar(ImPlot3DStyleVar_FillAlpha, 0.8f);
         if (selected_fill == 0)
             ImPlot3D::SetNextFillStyle(solid_color);
+
+        // Set line style
         ImPlot3D::SetNextLineStyle(ImPlot3D::GetColormapColor(1));
+
+        // Set marker style
+        ImPlot3D::SetNextMarkerStyle(ImPlot3DMarker_Square, IMPLOT3D_AUTO, ImPlot3D::GetColormapColor(2));
 
         // Plot the surface
         if (custom_range)
-            ImPlot3D::PlotSurface("Wave Surface", xs, ys, zs, N, N, (double)range_min, (double)range_max);
+            ImPlot3D::PlotSurface("Wave Surface", xs, ys, zs, N, N, (double)range_min, (double)range_max, flags);
         else
-            ImPlot3D::PlotSurface("Wave Surface", xs, ys, zs, N, N);
+            ImPlot3D::PlotSurface("Wave Surface", xs, ys, zs, N, N, 0.0, 0.0, flags);
 
         // End the plot
         ImPlot3D::PopStyleVar();

--- a/implot3d_items.cpp
+++ b/implot3d_items.cpp
@@ -1284,19 +1284,19 @@ template <typename _Getter> void PlotQuadEx(const char* label_id, const _Getter&
         const ImPlot3DNextItemData& n = GetItemData();
 
         // Render fill
-        if (getter.Count >= 4 && n.RenderFill) {
+        if (getter.Count >= 4 && n.RenderFill && !ImHasFlag(flags, ImPlot3DQuadFlags_NoFill)) {
             const ImU32 col_fill = ImGui::GetColorU32(n.Colors[ImPlot3DCol_Fill]);
             RenderPrimitives<RendererQuadFill>(getter, col_fill);
         }
 
         // Render lines
-        if (getter.Count >= 2 && n.RenderLine) {
+        if (getter.Count >= 2 && n.RenderLine && !ImHasFlag(flags, ImPlot3DQuadFlags_NoLines)) {
             const ImU32 col_line = ImGui::GetColorU32(n.Colors[ImPlot3DCol_Line]);
             RenderPrimitives<RendererLineSegments>(GetterQuadLines<_Getter>(getter), col_line, n.LineWeight);
         }
 
         // Render markers
-        if (n.Marker != ImPlot3DMarker_None) {
+        if (n.Marker != ImPlot3DMarker_None && !ImHasFlag(flags, ImPlot3DQuadFlags_NoMarkers)) {
             const ImU32 col_line = ImGui::GetColorU32(n.Colors[ImPlot3DCol_MarkerOutline]);
             const ImU32 col_fill = ImGui::GetColorU32(n.Colors[ImPlot3DCol_MarkerFill]);
             RenderMarkers<_Getter>(getter, n.Marker, n.MarkerSize, n.RenderMarkerFill, col_fill, n.RenderMarkerLine, col_line, n.MarkerWeight);

--- a/implot3d_items.cpp
+++ b/implot3d_items.cpp
@@ -1379,19 +1379,19 @@ void PlotMesh(const char* label_id, const ImPlot3DPoint* vtx, const unsigned int
         const ImPlot3DNextItemData& n = GetItemData();
 
         // Render fill
-        if (getter.Count >= 3 && n.RenderFill) {
+        if (getter.Count >= 3 && n.RenderFill && !ImHasFlag(flags, ImPlot3DMeshFlags_NoFill)) {
             const ImU32 col_fill = ImGui::GetColorU32(n.Colors[ImPlot3DCol_Fill]);
             RenderPrimitives<RendererTriangleFill>(getter_triangles, col_fill);
         }
 
         // Render lines
-        if (getter.Count >= 2 && n.RenderLine && !n.IsAutoLine) {
+        if (getter.Count >= 2 && n.RenderLine && !n.IsAutoLine && !ImHasFlag(flags, ImPlot3DMeshFlags_NoLines)) {
             const ImU32 col_line = ImGui::GetColorU32(n.Colors[ImPlot3DCol_Line]);
             RenderPrimitives<RendererLineSegments>(GetterTriangleLines<GetterMeshTriangles>(getter_triangles), col_line, n.LineWeight);
         }
 
         // Render markers
-        if (n.Marker != ImPlot3DMarker_None) {
+        if (n.Marker != ImPlot3DMarker_None && !ImHasFlag(flags, ImPlot3DMeshFlags_NoMarkers)) {
             const ImU32 col_line = ImGui::GetColorU32(n.Colors[ImPlot3DCol_MarkerOutline]);
             const ImU32 col_fill = ImGui::GetColorU32(n.Colors[ImPlot3DCol_MarkerFill]);
             RenderMarkers(getter, n.Marker, n.MarkerSize, n.RenderMarkerFill, col_fill, n.RenderMarkerLine, col_line, n.MarkerWeight);

--- a/implot3d_items.cpp
+++ b/implot3d_items.cpp
@@ -1330,19 +1330,19 @@ template <typename _Getter> void PlotSurfaceEx(const char* label_id, const _Gett
         const ImPlot3DNextItemData& n = GetItemData();
 
         // Render fill
-        if (getter.Count >= 4 && n.RenderFill) {
+        if (getter.Count >= 4 && n.RenderFill && !ImHasFlag(flags, ImPlot3DSurfaceFlags_NoFill)) {
             const ImU32 col_fill = ImGui::GetColorU32(n.Colors[ImPlot3DCol_Fill]);
             RenderPrimitives<RendererSurfaceFill>(getter, x_count, y_count, col_fill, scale_min, scale_max);
         }
 
         // Render lines
-        if (getter.Count >= 2 && n.RenderLine) {
+        if (getter.Count >= 2 && n.RenderLine && !ImHasFlag(flags, ImPlot3DSurfaceFlags_NoLines)) {
             const ImU32 col_line = ImGui::GetColorU32(n.Colors[ImPlot3DCol_Line]);
             RenderPrimitives<RendererLineSegments>(GetterSurfaceLines<_Getter>(getter, x_count, y_count), col_line, n.LineWeight);
         }
 
         // Render markers
-        if (n.Marker != ImPlot3DMarker_None) {
+        if (n.Marker != ImPlot3DMarker_None && !ImHasFlag(flags, ImPlot3DSurfaceFlags_NoMarkers)) {
             const ImU32 col_line = ImGui::GetColorU32(n.Colors[ImPlot3DCol_MarkerOutline]);
             const ImU32 col_fill = ImGui::GetColorU32(n.Colors[ImPlot3DCol_MarkerFill]);
             RenderMarkers<_Getter>(getter, n.Marker, n.MarkerSize, n.RenderMarkerFill, col_fill, n.RenderMarkerLine, col_line, n.MarkerWeight);

--- a/implot3d_items.cpp
+++ b/implot3d_items.cpp
@@ -1238,19 +1238,19 @@ template <typename _Getter> void PlotTriangleEx(const char* label_id, const _Get
         const ImPlot3DNextItemData& n = GetItemData();
 
         // Render fill
-        if (getter.Count >= 3 && n.RenderFill) {
+        if (getter.Count >= 3 && n.RenderFill && !ImHasFlag(flags, ImPlot3DTriangleFlags_NoFill)) {
             const ImU32 col_fill = ImGui::GetColorU32(n.Colors[ImPlot3DCol_Fill]);
             RenderPrimitives<RendererTriangleFill>(getter, col_fill);
         }
 
         // Render lines
-        if (getter.Count >= 2 && n.RenderLine) {
+        if (getter.Count >= 2 && n.RenderLine && !ImHasFlag(flags, ImPlot3DTriangleFlags_NoLines)) {
             const ImU32 col_line = ImGui::GetColorU32(n.Colors[ImPlot3DCol_Line]);
             RenderPrimitives<RendererLineSegments>(GetterTriangleLines<_Getter>(getter), col_line, n.LineWeight);
         }
 
         // Render markers
-        if (n.Marker != ImPlot3DMarker_None) {
+        if (n.Marker != ImPlot3DMarker_None && !ImHasFlag(flags, ImPlot3DTriangleFlags_NoMarkers)) {
             const ImU32 col_line = ImGui::GetColorU32(n.Colors[ImPlot3DCol_MarkerOutline]);
             const ImU32 col_fill = ImGui::GetColorU32(n.Colors[ImPlot3DCol_MarkerFill]);
             RenderMarkers<_Getter>(getter, n.Marker, n.MarkerSize, n.RenderMarkerFill, col_fill, n.RenderMarkerLine, col_line, n.MarkerWeight);


### PR DESCRIPTION
This PR implements the changes proposed in #76 by @fecaltransplant

The following flags were added:
- **PlotTriangle**: `ImPlot3DTriangleFlags_NoLines`, `ImPlot3DTriangleFlags_NoFill`, `ImPlot3DTriangleFlags_NoMarkers`
- **PlotQuad**: `ImPlot3DQuadFlags_NoLines`, `ImPlot3DQuadFlags_NoFill`, `ImPlot3DQuadFlags_NoMarkers`
- **PlotSurface**: `ImPlot3DSurfaceFlags_NoLines`, `ImPlot3DSurfaceFlags_NoFill`, `ImPlot3DSurfaceFlags_NoMarkers`
- **PlotMesh**: `ImPlot3DMeshFlags_NoLines`, `ImPlot3DMeshFlags_NoFill`, `ImPlot3DMeshFlags_NoMarkers`

The demos were also updated with these flags:

https://github.com/user-attachments/assets/21f215be-263e-4a45-bc99-04983ee0cbf3

https://github.com/user-attachments/assets/5a545756-288d-4639-aeda-d024cf43a5b1

https://github.com/user-attachments/assets/df85649b-24ba-4057-a78c-7b57f7e1530e

https://github.com/user-attachments/assets/7f5038b5-3373-49ac-bbae-fe119ea35032

This will allow users to easily disable lines/fill/markers for those plots, which can also have a significant impact on performance (as shown in the surface plot video above).