### PR TITLE
Feat: Axis constraints

### DIFF
--- a/implot3d.cpp
+++ b/implot3d.cpp
@@ -1534,8 +1534,8 @@ void SetupAxisLimitsConstraints(ImAxis3D idx, double v_min, double v_max) {
                          "Setup needs to be called after BeginPlot and before any setup locking functions (e.g. PlotX)!");
     ImPlot3DPlot& plot = *gp.CurrentPlot;
     ImPlot3DAxis& axis = plot.Axes[idx];
-    axis.ConstraintRange.Min = v_min;
-    axis.ConstraintRange.Max = v_max;
+    axis.ConstraintRange.Min = (float)v_min;
+    axis.ConstraintRange.Max = (float)v_max;
 }
 
 void SetupAxisZoomConstraints(ImAxis3D idx, double z_min, double z_max) {
@@ -1544,8 +1544,8 @@ void SetupAxisZoomConstraints(ImAxis3D idx, double z_min, double z_max) {
                          "Setup needs to be called after BeginPlot and before any setup locking functions (e.g. PlotX)!");
     ImPlot3DPlot& plot = *gp.CurrentPlot;
     ImPlot3DAxis& axis = plot.Axes[idx];
-    axis.ConstraintZoom.Min = z_min;
-    axis.ConstraintZoom.Max = z_max;
+    axis.ConstraintZoom.Min = (float)z_min;
+    axis.ConstraintZoom.Max = (float)z_max;
 }
 
 void SetupAxes(const char* x_label, const char* y_label, const char* z_label, ImPlot3DAxisFlags x_flags, ImPlot3DAxisFlags y_flags,

--- a/implot3d.cpp
+++ b/implot3d.cpp
@@ -3194,6 +3194,7 @@ void ImPlot3DAxis::ApplyFit() {
         Range.Max += 0.5;
         Range.Min -= 0.5;
     }
+    Constrain();
     FitExtents.Min = HUGE_VAL;
     FitExtents.Max = -HUGE_VAL;
 }

--- a/implot3d.cpp
+++ b/implot3d.cpp
@@ -1528,6 +1528,26 @@ void SetupAxisTicks(ImAxis3D idx, double v_min, double v_max, int n_ticks, const
     SetupAxisTicks(idx, temp.Data, n_ticks, labels, keep_default);
 }
 
+void SetupAxisLimitsConstraints(ImAxis3D idx, double v_min, double v_max) {
+    ImPlot3DContext& gp = *GImPlot3D;
+    IM_ASSERT_USER_ERROR(gp.CurrentPlot != nullptr && !gp.CurrentPlot->SetupLocked,
+                         "Setup needs to be called after BeginPlot and before any setup locking functions (e.g. PlotX)!");
+    ImPlot3DPlot& plot = *gp.CurrentPlot;
+    ImPlot3DAxis& axis = plot.Axes[idx];
+    axis.ConstraintRange.Min = v_min;
+    axis.ConstraintRange.Max = v_max;
+}
+
+void SetupAxisZoomConstraints(ImAxis3D idx, double z_min, double z_max) {
+    ImPlot3DContext& gp = *GImPlot3D;
+    IM_ASSERT_USER_ERROR(gp.CurrentPlot != nullptr && !gp.CurrentPlot->SetupLocked,
+                         "Setup needs to be called after BeginPlot and before any setup locking functions (e.g. PlotX)!");
+    ImPlot3DPlot& plot = *gp.CurrentPlot;
+    ImPlot3DAxis& axis = plot.Axes[idx];
+    axis.ConstraintZoom.Min = z_min;
+    axis.ConstraintZoom.Max = z_max;
+}
+
 void SetupAxes(const char* x_label, const char* y_label, const char* z_label, ImPlot3DAxisFlags x_flags, ImPlot3DAxisFlags y_flags,
                ImPlot3DAxisFlags z_flags) {
     SetupAxis(ImAxis3D_X, x_label, x_flags);

--- a/implot3d.cpp
+++ b/implot3d.cpp
@@ -1983,7 +1983,8 @@ void HandleInput(ImPlot3DPlot& plot) {
             // Adjust plot range to translate the plot
             for (int i = 0; i < 3; i++) {
                 if (plot.Axes[i].Hovered) {
-                    if (!plot.Axes[i].IsInputLocked()) {
+                    bool increasing = delta_plot[i] < 0.0f;
+                    if (delta_plot[i] != 0.0f && !plot.Axes[i].IsPanLocked(increasing)) {
                         plot.Axes[i].SetMin(plot.Axes[i].Range.Min - delta_plot[i]);
                         plot.Axes[i].SetMax(plot.Axes[i].Range.Max - delta_plot[i]);
                     }
@@ -2007,7 +2008,8 @@ void HandleInput(ImPlot3DPlot& plot) {
             // Apply translation to the selected axes
             for (int i = 0; i < 3; i++) {
                 if (plot.Axes[i].Hovered) {
-                    if (!plot.Axes[i].IsInputLocked()) {
+                    bool increasing = delta_plot[i] < 0.0f;
+                    if (delta_plot[i] != 0.0f && !plot.Axes[i].IsPanLocked(increasing)) {
                         plot.Axes[i].SetMin(plot.Axes[i].Range.Min - delta_plot[i]);
                         plot.Axes[i].SetMax(plot.Axes[i].Range.Max - delta_plot[i]);
                     }

--- a/implot3d.h
+++ b/implot3d.h
@@ -389,7 +389,7 @@ IMPLOT3D_API void SetupAxis(ImAxis3D axis, const char* label = nullptr, ImPlot3D
 
 IMPLOT3D_API void SetupAxisLimits(ImAxis3D axis, double v_min, double v_max, ImPlot3DCond cond = ImPlot3DCond_Once);
 
-IMPLOT3D_API void SetupAxisFormat(ImAxis3D idx, ImPlot3DFormatter formatter, void* data = nullptr);
+IMPLOT3D_API void SetupAxisFormat(ImAxis3D axis, ImPlot3DFormatter formatter, void* data = nullptr);
 
 // Sets an axis' ticks and optionally the labels. To keep the default ticks, set #keep_default=true
 IMPLOT3D_API void SetupAxisTicks(ImAxis3D axis, const double* values, int n_ticks, const char* const labels[] = nullptr, bool keep_default = false);
@@ -397,6 +397,12 @@ IMPLOT3D_API void SetupAxisTicks(ImAxis3D axis, const double* values, int n_tick
 // Sets an axis' ticks and optionally the labels for the next plot. To keep the default ticks, set #keep_default=true
 IMPLOT3D_API void SetupAxisTicks(ImAxis3D axis, double v_min, double v_max, int n_ticks, const char* const labels[] = nullptr,
                                  bool keep_default = false);
+
+// Sets an axis' limits constraints
+IMPLOT3D_API void SetupAxisLimitsConstraints(ImAxis3D axis, double v_min, double v_max);
+
+// Sets an axis' zoom constraints
+IMPLOT3D_API void SetupAxisZoomConstraints(ImAxis3D axis, double z_min, double z_max);
 
 // Sets the label and/or flags for primary X/Y/Z axes (shorthand for three calls to SetupAxis)
 IMPLOT3D_API void SetupAxes(const char* x_label, const char* y_label, const char* z_label, ImPlot3DAxisFlags x_flags = 0,

--- a/implot3d.h
+++ b/implot3d.h
@@ -277,6 +277,7 @@ enum ImPlot3DAxisFlags_ {
     ImPlot3DAxisFlags_LockMax = 1 << 5,      // The axis maximum value will be locked when panning/zooming
     ImPlot3DAxisFlags_AutoFit = 1 << 6,      // Axis will be auto-fitting to data extents
     ImPlot3DAxisFlags_Invert = 1 << 7,       // The axis will be inverted
+    ImPlot3DAxisFlags_PanStretch = 1 << 8,   // Panning in a locked or constrained state will cause the axis to stretch if possible
     ImPlot3DAxisFlags_Lock = ImPlot3DAxisFlags_LockMin | ImPlot3DAxisFlags_LockMax,
     ImPlot3DAxisFlags_NoDecorations = ImPlot3DAxisFlags_NoLabel | ImPlot3DAxisFlags_NoGridLines | ImPlot3DAxisFlags_NoTickLabels,
 };

--- a/implot3d_demo.cpp
+++ b/implot3d_demo.cpp
@@ -723,7 +723,7 @@ void DemoAxisConstraints() {
     static ImPlot3DAxisFlags flags;
     ImGui::DragFloat2("Limits Constraints", limit_constraints, 0.01f);
     ImGui::DragFloat2("Zoom Constraints", zoom_constraints, 0.01f);
-    // CHECKBOX_FLAG(flags, ImPlot3DAxisFlags_PanStretch);
+    CHECKBOX_FLAG(flags, ImPlot3DAxisFlags_PanStretch);
     if (ImPlot3D::BeginPlot("##AxisConstraints", ImVec2(-1, 0))) {
         ImPlot3D::SetupAxes("X", "Y", "Z", flags, flags, flags);
         ImPlot3D::SetupAxesLimits(-1, 1, -1, 1, -1, 1);

--- a/implot3d_demo.cpp
+++ b/implot3d_demo.cpp
@@ -717,6 +717,26 @@ void DemoTickLabels() {
     }
 }
 
+void DemoAxisConstraints() {
+    static float limit_constraints[2] = {-10, 10};
+    static float zoom_constraints[2] = {1, 20};
+    static ImPlot3DAxisFlags flags;
+    ImGui::DragFloat2("Limits Constraints", limit_constraints, 0.01f);
+    ImGui::DragFloat2("Zoom Constraints", zoom_constraints, 0.01f);
+    // CHECKBOX_FLAG(flags, ImPlot3DAxisFlags_PanStretch);
+    if (ImPlot3D::BeginPlot("##AxisConstraints", ImVec2(-1, 0))) {
+        ImPlot3D::SetupAxes("X", "Y", "Z", flags, flags, flags);
+        ImPlot3D::SetupAxesLimits(-1, 1, -1, 1, -1, 1);
+        ImPlot3D::SetupAxisLimitsConstraints(ImAxis3D_X, limit_constraints[0], limit_constraints[1]);
+        ImPlot3D::SetupAxisLimitsConstraints(ImAxis3D_Y, limit_constraints[0], limit_constraints[1]);
+        ImPlot3D::SetupAxisLimitsConstraints(ImAxis3D_Z, limit_constraints[0], limit_constraints[1]);
+        ImPlot3D::SetupAxisZoomConstraints(ImAxis3D_X, zoom_constraints[0], zoom_constraints[1]);
+        ImPlot3D::SetupAxisZoomConstraints(ImAxis3D_Y, zoom_constraints[0], zoom_constraints[1]);
+        ImPlot3D::SetupAxisZoomConstraints(ImAxis3D_Z, zoom_constraints[0], zoom_constraints[1]);
+        ImPlot3D::EndPlot();
+    }
+}
+
 //-----------------------------------------------------------------------------
 // [SECTION] Custom
 //-----------------------------------------------------------------------------
@@ -864,6 +884,7 @@ void ShowAllDemos() {
             DemoHeader("Box Scale", DemoBoxScale);
             DemoHeader("Box Rotation", DemoBoxRotation);
             DemoHeader("Tick Labels", DemoTickLabels);
+            DemoHeader("Axis Constraints", DemoAxisConstraints);
             ImGui::EndTabItem();
         }
         if (ImGui::BeginTabItem("Custom")) {

--- a/implot3d_internal.h
+++ b/implot3d_internal.h
@@ -553,8 +553,8 @@ struct ImPlot3DAxis {
     }
 
     inline void Constrain() {
-        Range.Min = (float)ImPlot3D::ImConstrainNan(ImPlot3D::ImConstrainInf((double)Range.Min));
-        Range.Max = (float)ImPlot3D::ImConstrainNan(ImPlot3D::ImConstrainInf((double)Range.Max));
+        Range.Min = (float)ImPlot3D::ImConstrainNan((float)ImPlot3D::ImConstrainInf((double)Range.Min));
+        Range.Max = (float)ImPlot3D::ImConstrainNan((float)ImPlot3D::ImConstrainInf((double)Range.Max));
         if (Range.Min < ConstraintRange.Min)
             Range.Min = ConstraintRange.Min;
         if (Range.Max > ConstraintRange.Max)

--- a/implot3d_internal.h
+++ b/implot3d_internal.h
@@ -553,20 +553,20 @@ struct ImPlot3DAxis {
     }
 
     inline void Constrain() {
-        Range.Min = ImPlot3D::ImConstrainNan(ImPlot3D::ImConstrainInf(Range.Min));
-        Range.Max = ImPlot3D::ImConstrainNan(ImPlot3D::ImConstrainInf(Range.Max));
+        Range.Min = (float)ImPlot3D::ImConstrainNan(ImPlot3D::ImConstrainInf((double)Range.Min));
+        Range.Max = (float)ImPlot3D::ImConstrainNan(ImPlot3D::ImConstrainInf((double)Range.Max));
         if (Range.Min < ConstraintRange.Min)
             Range.Min = ConstraintRange.Min;
         if (Range.Max > ConstraintRange.Max)
             Range.Max = ConstraintRange.Max;
-        double zoom = Range.Size();
+        float zoom = Range.Size();
         if (zoom < ConstraintZoom.Min) {
-            double delta = (ConstraintZoom.Min - zoom) * 0.5;
+            float delta = (ConstraintZoom.Min - zoom) * 0.5f;
             Range.Min -= delta;
             Range.Max += delta;
         }
         if (zoom > ConstraintZoom.Max) {
-            double delta = (zoom - ConstraintZoom.Max) * 0.5;
+            float delta = (zoom - ConstraintZoom.Max) * 0.5f;
             Range.Min += delta;
             Range.Max -= delta;
         }

--- a/implot3d_internal.h
+++ b/implot3d_internal.h
@@ -582,6 +582,19 @@ struct ImPlot3DAxis {
     inline bool IsInputLockedMax() const { return IsLockedMax() || IsAutoFitting(); }
     inline bool IsInputLocked() const { return IsLocked() || IsAutoFitting(); }
 
+    inline bool IsPanLocked(bool increasing) {
+        if (ImPlot3D::ImHasFlag(Flags, ImPlot3DAxisFlags_PanStretch)) {
+            return IsInputLocked();
+        } else {
+            if (IsLockedMin() || IsLockedMax() || IsAutoFitting())
+                return false;
+            if (increasing)
+                return Range.Max == ConstraintRange.Max;
+            else
+                return Range.Min == ConstraintRange.Min;
+        }
+    }
+
     inline void SetLabel(const char* label) {
         Label.Buf.shrink(0);
         if (label && ImGui::FindRenderedTextEnd(label, nullptr) != label)


### PR DESCRIPTION
Closes #119

Just like ImPlot, ImPlot3D should support axis constraints, both range and zoom constraints. The following APIs were implemented:
- `ImPlot3D::SetupAxisLimitsConstraints`
- `ImPlot3D::SetupAxisZoomConstraints`

A new axis flag was also added: `ImPlot3DAxisFlags_PanStretch`

A new demo was added (3D equivalent of ImPlot's demo)

https://github.com/user-attachments/assets/c04fc821-5396-4425-8f05-0758116e59df
