### PR TITLE
Fix: Inconsistent rotation direction

### DIFF
--- a/implot3d.cpp
+++ b/implot3d.cpp
@@ -2204,19 +2204,23 @@ void HandleInput(ImPlot3DPlot& plot) {
         float angle_x = delta.x * (3.1415f / 180.0f);
         float angle_y = delta.y * (3.1415f / 180.0f);
 
-        // Detect if the plot is upside down by checking the transformed up vector
-        ImPlot3DPoint up_vector = plot.Rotation * ImPlot3DPoint(0.0f, 0.0f, 1.0f);
-        bool is_upside_down = up_vector.z < 0.0f;
+        // If drag just started, determine and store the rotation axis
+        if (plot.DragRotationAxis == ImPlot3DPoint(0.0f, 0.0f, 0.0f)) {
+            ImPlot3DPoint up_vector = plot.Rotation * ImPlot3DPoint(0.0f, 0.0f, 1.0f);
+            bool is_upside_down = up_vector.z < 0.0f;
+            plot.DragRotationAxis = is_upside_down ? ImPlot3DPoint(0.0f, 0.0f, -1.0f) : ImPlot3DPoint(0.0f, 0.0f, 1.0f);
+        }
 
         // Create quaternions for the rotations
         ImPlot3DQuat quat_x(angle_y, ImPlot3DPoint(1.0f, 0.0f, 0.0f));
-        // Use -Z axis rotation when upside down to fix inverted rotation behavior
-        ImPlot3DPoint z_axis = is_upside_down ? ImPlot3DPoint(0.0f, 0.0f, -1.0f) : ImPlot3DPoint(0.0f, 0.0f, 1.0f);
-        ImPlot3DQuat quat_z(angle_x, z_axis);
+        ImPlot3DQuat quat_z(angle_x, plot.DragRotationAxis);
 
         // Combine the new rotations with the current rotation
         plot.Rotation = quat_x * plot.Rotation * quat_z;
         plot.Rotation.Normalize();
+    } else {
+        // Reset drag rotation axis when not dragging
+        plot.DragRotationAxis = ImPlot3DPoint(0.0f, 0.0f, 0.0f);
     }
 
     // ZOOM -------------------------------------------------------------------

--- a/implot3d_internal.h
+++ b/implot3d_internal.h
@@ -662,8 +662,9 @@ struct ImPlot3DPlot {
     bool SetupLocked;
     bool Hovered;
     bool Held;
-    int HeldEdgeIdx;  // Index of the edge being held
-    int HeldPlaneIdx; // Index of the plane being held
+    int HeldEdgeIdx;                // Index of the edge being held
+    int HeldPlaneIdx;               // Index of the plane being held
+    ImPlot3DPoint DragRotationAxis; // Axis of rotation for the duration of a drag
     // Fit data
     bool FitThisFrame;
     // Items
@@ -689,6 +690,7 @@ struct ImPlot3DPlot {
         Hovered = Held = false;
         HeldEdgeIdx = -1;
         HeldPlaneIdx = -1;
+        DragRotationAxis = ImPlot3DPoint(0.0f, 0.0f, 0.0f);
         FitThisFrame = true;
         ContextClick = false;
         OpenContextThisFrame = false;


### PR DESCRIPTION
Fixes #145

This pull request fixes a bug where the plot's horizontal rotation direction would abruptly invert when the plot passed a certain threshold (i.e., became "upside down").

**Description**

The previous implementation checked if the plot was upside down on every frame of a drag rotation, switching the rotation axis between `+Z` and `-Z` mid-drag. This caused a jarring reversal of the perceived rotation direction if a drag gesture was long enough to flip the plot's orientation.

This change ensures the rotation axis is determined **once** at the start of the drag gesture and remains consistent throughout the interaction.

**Changes Made**

1.  Added an `ImPlot3DPoint DragRotationAxis` member to the `ImPlot3DPlot` struct to store the rotation axis for the duration of a drag.
2.  Modified `HandleInput()` in `implot3d.cpp` to:
    *   Detect when a new rotation drag begins.
    *   Determine the correct vertical rotation axis (`+Z` or `-Z`) based on the plot's orientation at the start of the drag.
    *   Store this axis in `plot.DragRotationAxis`.
    *   Use the stored `plot.DragRotationAxis` for all subsequent rotation calculations within that same drag.
    *   Reset the `DragRotationAxis` when the drag is released.

This restores an intuitive and consistent rotation behavior for the user.


**Before**

https://github.com/user-attachments/assets/435653de-4cef-456f-881e-40490a8df478

**After**

https://github.com/user-attachments/assets/faf1092d-935a-43df-91c3-ba205cd6ca13
