### PR TITLE
feat: ImPlot3D Flags for disabling user input (pan/rotate/zoom/all)

### DIFF
--- a/implot3d.cpp
+++ b/implot3d.cpp
@@ -1983,6 +1983,9 @@ ImPlot3DRay NDCRayToPlotRay(const ImPlot3DRay& ray) {
 static const float MOUSE_CURSOR_DRAG_THRESHOLD = 5.0f;
 
 void HandleInput(ImPlot3DPlot& plot) {
+    if (ImHasFlag(plot.Flags, ImPlot3DFlags_NoInputs))
+        return;
+
     ImGuiIO& IO = ImGui::GetIO();
 
     // clang-format off

--- a/implot3d.h
+++ b/implot3d.h
@@ -110,6 +110,7 @@ enum ImPlot3DFlags_ {
     ImPlot3DFlags_NoRotate = 1 << 6,    // Lock rotation interaction
     ImPlot3DFlags_NoPan = 1 << 7,       // Lock panning/translation interaction
     ImPlot3DFlags_NoZoom = 1 << 8,      // Lock zoom interaction
+    ImPlot3DFlags_NoInputs = 1 << 9,    // Disable all user inputs
     ImPlot3DFlags_CanvasOnly = ImPlot3DFlags_NoTitle | ImPlot3DFlags_NoLegend | ImPlot3DFlags_NoMouseText,
 };
 

--- a/implot3d_demo.cpp
+++ b/implot3d_demo.cpp
@@ -803,6 +803,13 @@ void DemoPlotFlags() {
         ImGui::SetTooltip("Lock zooming interaction");
     }
 
+    CHECKBOX_FLAG(flags, ImPlot3DFlags_NoInputs);
+    ImGui::SameLine();
+    ImGui::TextDisabled("(?)");
+    if (ImGui::IsItemHovered()) {
+        ImGui::SetTooltip("Disable all user inputs");
+    }
+
     if (ImPlot3D::BeginPlot("Plot Flags Demo", ImVec2(-1, 0), flags)) {
         ImPlot3D::SetupAxes("X-axis", "Y-axis", "Z-axis");
         ImPlot3D::SetupAxesLimits(-10, 10, -10, 10, -5, 5);


### PR DESCRIPTION
Closes #107

@brenocq Simple implementation of the flags for locking pan/zoom/rotate respectively on a 3D plot.

This is my first ever implot3d PR and open-source PR in general for that matter, so I thought I'd select a more straightforward feature.

One thing to note is that I'm not certain if the desired behavior should be to also disable altering the rotation/pan state of the plot through the double-left click functionality. I can see arguments for both cases.

https://github.com/user-attachments/assets/50682574-3350-4e81-a906-3233f4193d0c

