### PR TITLE
Feature: Implementation of Per Point Custom Color for Plots of Line, Scatter and Surface

### DIFF
--- a/implot3d.cpp
+++ b/implot3d.cpp
@@ -3069,6 +3069,15 @@ ImU32 SampleColormapU32(float t, ImPlot3DColormap cmap) {
 
 ImVec4 SampleColormap(float t, ImPlot3DColormap cmap) { return ImGui::ColorConvertU32ToFloat4(SampleColormapU32(t, cmap)); }
 
+template <typename T>
+void ConvertValueToColor(T* value, ImU32* cs, int count, float v_min, float v_max, ImPlot3DColormap colormap) {
+    for (int i = 0; i < count; i++)
+        cs[i] = SampleColormapU32(ImClamp(ImRemap01(static_cast<float>(value[i]), v_min, v_max), 0.0f, 1.0f), colormap);
+}
+template void ConvertValueToColor<double>(double* value, ImU32* cs, int count, float v_min, float v_max, ImPlot3DColormap colormap);
+template void ConvertValueToColor<float>(float* value, ImU32* cs, int count, float v_min, float v_max, ImPlot3DColormap colormap);
+template void ConvertValueToColor<int>(int* value, ImU32* cs, int count, float v_min, float v_max, ImPlot3DColormap colormap);
+
 void RenderColorBar(const ImU32* colors, int size, ImDrawList& DrawList, const ImRect& bounds, bool vert, bool reversed, bool continuous) {
     const int n = continuous ? size - 1 : size;
     ImU32 col1, col2;


### PR DESCRIPTION
In this PR, users can add an array storing the value at each point (such as temperature, density, etc.) and assign the color to each point according to the selected colormap. The existing functionality and invoking methods are not influenced by this modification. The demo can be found in the figures below.

<img width="657" height="1161" alt="Image" src="https://github.com/user-attachments/assets/3fe5927b-35e9-48b9-b462-cdac353cd619" />
<img width="669" height="926" alt="Image" src="https://github.com/user-attachments/assets/b98b0dd7-2983-46f1-ab6d-4bc4f5991bee" />