### PR TITLE
Chore: Fix unused variable warnings

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Configure
         run: |
           cd example
-          cmake -B build -DCMAKE_CXX_COMPILER=${{ matrix.compiler }} -DCMAKE_CXX_FLAGS="-Wall -Werror"
+          cmake -B build -DCMAKE_CXX_COMPILER=${{ matrix.compiler }} -DCMAKE_CXX_FLAGS="-Wall -Wextra -Werror"
       - name: Build
         run: |
           cd example

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -11,5 +11,5 @@ jobs:
       - name: Build
         run: |
           cd example
-          cmake -B build -DCMAKE_CXX_FLAGS="-Wall -Werror"
+          cmake -B build -DCMAKE_CXX_FLAGS="-Wall -Wextra -Werror"
           cmake --build build

--- a/implot3d.cpp
+++ b/implot3d.cpp
@@ -296,7 +296,7 @@ ImVec2 CalcLegendSize(ImPlot3DItemGroup& items, const ImVec2& pad, const ImVec2&
     return legend_size;
 }
 
-void ShowLegendEntries(ImPlot3DItemGroup& items, const ImRect& legend_bb, bool /*hovered*/, const ImVec2& pad, const ImVec2& spacing, bool vertical,
+void ShowLegendEntries(ImPlot3DItemGroup& items, const ImRect& legend_bb, const ImVec2& pad, const ImVec2& spacing, bool vertical,
                        ImDrawList& draw_list) {
     const float txt_ht = ImGui::GetTextLineHeight();
     const float icon_size = txt_ht;
@@ -391,7 +391,7 @@ void RenderLegend() {
     draw_list->AddRect(legend.Rect.Min, legend.Rect.Max, col_bd);
 
     // Render legends
-    ShowLegendEntries(plot.Items, legend.Rect, legend.Hovered, gp.Style.LegendInnerPadding, gp.Style.LegendSpacing, !legend_horz, *draw_list);
+    ShowLegendEntries(plot.Items, legend.Rect, gp.Style.LegendInnerPadding, gp.Style.LegendSpacing, !legend_horz, *draw_list);
 }
 
 //-----------------------------------------------------------------------------
@@ -520,7 +520,7 @@ int Active3DFacesToAxisLookupIndex(const bool* active_faces) {
     return ((int)active_faces[0] << 2) | ((int)active_faces[1] << 1) | ((int)active_faces[2]);
 }
 
-int GetMouseOverPlane(const ImPlot3DPlot& /*plot*/, const bool* active_faces, const ImVec2* corners_pix, int* plane_out = nullptr) {
+int GetMouseOverPlane(const bool* active_faces, const ImVec2* corners_pix, int* plane_out = nullptr) {
     ImGuiIO& io = ImGui::GetIO();
     ImVec2 mouse_pos = io.MousePos;
     if (plane_out)
@@ -545,7 +545,7 @@ int GetMouseOverPlane(const ImPlot3DPlot& /*plot*/, const bool* active_faces, co
     return -1; // Not over any active plane
 }
 
-int GetMouseOverAxis(const ImPlot3DPlot& /*plot*/, const bool* active_faces, const ImVec2* corners_pix, const int plane_2d, int* edge_out = nullptr) {
+int GetMouseOverAxis(const bool* active_faces, const ImVec2* corners_pix, const int plane_2d, int* edge_out = nullptr) {
     const float axis_proximity_threshold = 15.0f; // Distance in pixels to consider the mouse "close" to an axis
 
     ImGuiIO& io = ImGui::GetIO();
@@ -599,8 +599,8 @@ void RenderPlotBackground(ImDrawList* draw_list, const ImPlot3DPlot& plot, const
     int hovered_plane = -1;
     if (!plot.Held) {
         // If the mouse is not held, highlight plane hovering when mouse over it
-        hovered_plane = GetMouseOverPlane(plot, active_faces, corners_pix);
-        if (GetMouseOverAxis(plot, active_faces, corners_pix, plane_2d) != -1)
+        hovered_plane = GetMouseOverPlane(active_faces, corners_pix);
+        if (GetMouseOverAxis(active_faces, corners_pix, plane_2d) != -1)
             hovered_plane = -1;
     } else {
         // If the mouse is held, highlight the held plane
@@ -619,7 +619,7 @@ void RenderPlotBackground(ImDrawList* draw_list, const ImPlot3DPlot& plot, const
 void RenderPlotBorder(ImDrawList* draw_list, const ImPlot3DPlot& plot, const ImVec2* corners_pix, const bool* active_faces, const int plane_2d) {
     int hovered_edge = -1;
     if (!plot.Held)
-        GetMouseOverAxis(plot, active_faces, corners_pix, plane_2d, &hovered_edge);
+        GetMouseOverAxis(active_faces, corners_pix, plane_2d, &hovered_edge);
     else
         hovered_edge = plot.HeldEdgeIdx;
 
@@ -2185,9 +2185,9 @@ void HandleInput(ImPlot3DPlot& plot) {
     ImVec2 corners_pix[8];
     ComputeBoxCornersPix(plot, corners_pix, corners);
     int hovered_plane_idx = -1;
-    int hovered_plane = GetMouseOverPlane(plot, active_faces, corners_pix, &hovered_plane_idx);
+    int hovered_plane = GetMouseOverPlane(active_faces, corners_pix, &hovered_plane_idx);
     int hovered_edge_idx = -1;
-    int hovered_axis = GetMouseOverAxis(plot, active_faces, corners_pix, plane_2d, &hovered_edge_idx);
+    int hovered_axis = GetMouseOverAxis(active_faces, corners_pix, plane_2d, &hovered_edge_idx);
     if (hovered_axis != -1) {
         hovered_plane_idx = -1;
         hovered_plane = -1;

--- a/implot3d.cpp
+++ b/implot3d.cpp
@@ -296,7 +296,7 @@ ImVec2 CalcLegendSize(ImPlot3DItemGroup& items, const ImVec2& pad, const ImVec2&
     return legend_size;
 }
 
-void ShowLegendEntries(ImPlot3DItemGroup& items, const ImRect& legend_bb, bool hovered, const ImVec2& pad, const ImVec2& spacing, bool vertical,
+void ShowLegendEntries(ImPlot3DItemGroup& items, const ImRect& legend_bb, bool /*hovered*/, const ImVec2& pad, const ImVec2& spacing, bool vertical,
                        ImDrawList& draw_list) {
     const float txt_ht = ImGui::GetTextLineHeight();
     const float icon_size = txt_ht;
@@ -520,7 +520,7 @@ int Active3DFacesToAxisLookupIndex(const bool* active_faces) {
     return ((int)active_faces[0] << 2) | ((int)active_faces[1] << 1) | ((int)active_faces[2]);
 }
 
-int GetMouseOverPlane(const ImPlot3DPlot& plot, const bool* active_faces, const ImVec2* corners_pix, int* plane_out = nullptr) {
+int GetMouseOverPlane(const ImPlot3DPlot& /*plot*/, const bool* active_faces, const ImVec2* corners_pix, int* plane_out = nullptr) {
     ImGuiIO& io = ImGui::GetIO();
     ImVec2 mouse_pos = io.MousePos;
     if (plane_out)
@@ -545,7 +545,7 @@ int GetMouseOverPlane(const ImPlot3DPlot& plot, const bool* active_faces, const 
     return -1; // Not over any active plane
 }
 
-int GetMouseOverAxis(const ImPlot3DPlot& plot, const bool* active_faces, const ImVec2* corners_pix, const int plane_2d, int* edge_out = nullptr) {
+int GetMouseOverAxis(const ImPlot3DPlot& /*plot*/, const bool* active_faces, const ImVec2* corners_pix, const int plane_2d, int* edge_out = nullptr) {
     const float axis_proximity_threshold = 15.0f; // Distance in pixels to consider the mouse "close" to an axis
 
     ImGuiIO& io = ImGui::GetIO();

--- a/implot3d.h
+++ b/implot3d.h
@@ -920,6 +920,8 @@ struct ImPlot3DStyle {
     // Constructor
     IMPLOT3D_API ImPlot3DStyle();
     ImPlot3DStyle(const ImPlot3DStyle& other) = default;
+    ImPlot3DStyle& operator=(const ImPlot3DStyle& other) =
+  default;
 };
 
 //-----------------------------------------------------------------------------

--- a/implot3d_items.cpp
+++ b/implot3d_items.cpp
@@ -697,7 +697,7 @@ template <class _Getter> struct RendererQuadImage : RendererBase {
                       ImU32 col)
         : RendererBase(getter.Count / 4, 6, 4), Getter(getter), TexRef(tex_ref), UV0(uv0), UV1(uv1), UV2(uv2), UV3(uv3), Col(col) {}
 
-    void Init(ImDrawList3D& draw_list_3d) const {}
+    void Init(ImDrawList3D& /*draw_list_3d*/) const {}
 
     IMPLOT3D_INLINE bool Render(ImDrawList3D& draw_list_3d, const ImPlot3DBox& cull_box, int prim) const {
         ImPlot3DPoint p_plot[4];


### PR DESCRIPTION
I found a few places in the code where function arguments were not being used, and gcc/clang was giving warnings regarding unused variables. I have commented out the variable names here to silence these warnings. I don't _think_ these are bugs, but I definitely don't know enough about the project to be sure, so you should definitely check to see if this is really the case.