### PR TITLE
Fix: Initialize plane_2d to -1 in ShowMetricsWindow

### DIFF
--- a/implot3d.cpp
+++ b/implot3d.cpp
@@ -3928,7 +3928,7 @@ void ImPlot3D::ShowMetricsWindow(bool* p_popen) {
     bool active_faces[3];
     ImVec2 corners_pix[8];
     ImPlot3DPoint corners[8];
-    int plane_2d;
+    int plane_2d = -1;
     int axis_corners[3][2];
     char buff[16];
     // Enum used to indicate how a certain type will be displayed


### PR DESCRIPTION
Initialize local variable plane_2d to -1 in ShowMetricsWindow to address MSVC warning C4701: "potentially uninitialized local variable 'plane_2d' used". This sets a known sentinel value to avoid use-before-initialization and undefined behavior, while preserving existing logic and silencing the compiler warning.

<img width="591" height="37" alt="image" src="https://github.com/user-attachments/assets/c59fbd1c-0cc0-4df7-830a-9b8315625afb" />
