### PR TITLE
Feat: Improved axis interaction area

### DIFF
--- a/implot3d.cpp
+++ b/implot3d.cpp
@@ -741,7 +741,7 @@ void RenderPlotBackground(ImDrawList* draw_list, const ImPlot3DPlot& plot, const
     }
 }
 
-void RenderAxisRects(ImDrawList* draw_list, const ImPlot3DPlot& plot, const ImVec2* corners_pix, const bool* active_faces, const int plane_2d,
+void RenderAxisRects(ImDrawList* draw_list, const ImPlot3DPlot& plot, const ImVec2* corners_pix, const bool*, const int plane_2d,
                      const int axis_corners[3][2]) {
     const float tick_label_offset = 20.0f; // Base offset from axis to tick labels
     const float axis_label_padding = 5.0f; // Padding between tick labels and axis label
@@ -838,7 +838,7 @@ void RenderAxisRects(ImDrawList* draw_list, const ImPlot3DPlot& plot, const ImVe
     }
 }
 
-void RenderPlotBorder(ImDrawList* draw_list, const ImPlot3DPlot& plot, const ImVec2* corners_pix, const bool* active_faces, const int plane_2d) {
+void RenderPlotBorder(ImDrawList* draw_list, const ImPlot3DPlot&, const ImVec2* corners_pix, const bool* active_faces, const int plane_2d) {
     // Determine which edges to render (all visible edges)
     bool render_edge[12];
     for (int i = 0; i < 12; i++)
@@ -1188,7 +1188,7 @@ void RenderTickLabels(ImDrawList* draw_list, const ImPlot3DPlot& plot, const ImP
     }
 }
 
-void RenderAxisLabels(ImDrawList* draw_list, const ImPlot3DPlot& plot, const ImPlot3DPoint* corners, const ImVec2* corners_pix,
+void RenderAxisLabels(ImDrawList* draw_list, const ImPlot3DPlot& plot, const ImPlot3DPoint*, const ImVec2* corners_pix,
                       const int axis_corners[3][2]) {
     ImU32 col_ax_txt = GetStyleColorU32(ImPlot3DCol_AxisText);
     const float tick_label_offset = 20.0f; // Base offset from axis to tick labels

--- a/implot3d.cpp
+++ b/implot3d.cpp
@@ -631,7 +631,7 @@ float ComputeMaxTickLabelExtent(const ImPlot3DAxis& axis);
 
 int GetMouseOverAxis(const ImPlot3DPlot& plot, const ImVec2* corners_pix, const int plane_2d, const int axis_corners[3][2], int* edge_out = nullptr) {
     const float inner_pad = 5.0f;
-    const float axis_label_padding = 5.0f;
+    const float axis_label_padding = 10.0f;
 
     ImGuiIO& io = ImGui::GetIO();
     ImVec2 mouse_pos = io.MousePos;
@@ -735,7 +735,7 @@ void RenderPlotBackground(ImDrawList* draw_list, const ImPlot3DPlot& plot, const
 void RenderAxisRects(ImDrawList* draw_list, const ImPlot3DPlot& plot, const ImVec2* corners_pix, const bool*, const int plane_2d,
                      const int axis_corners[3][2]) {
     const float inner_pad = 5.0f;
-    const float axis_label_padding = 5.0f;
+    const float axis_label_padding = 10.0f;
 
     int hovered_edge = -1;
     if (!plot.Held)
@@ -1151,7 +1151,7 @@ void RenderAxisLabels(ImDrawList* draw_list, const ImPlot3DPlot& plot, const ImP
                       const int axis_corners[3][2]) {
     ImU32 col_ax_txt = GetStyleColorU32(ImPlot3DCol_AxisText);
     const float inner_pad = 5.0f;       // Gap from axis edge to inner edge of tick labels
-    const float axis_label_padding = 5.0f; // Gap between tick label outer edge and axis label center
+    const float axis_label_padding = 10.0f; // Gap between tick label outer edge and axis label center
 
     for (int a = 0; a < 3; a++) {
         const ImPlot3DAxis& axis = plot.Axes[a];

--- a/implot3d.cpp
+++ b/implot3d.cpp
@@ -48,7 +48,6 @@ Below is a change-log of API breaking changes only. If you are using one of the 
 When you are not sure about an old symbol or function name, try using the Search/Find function of your IDE to look for comments or references in all
 implot3d files. You can read releases logs https://github.com/brenocq/implot3d/releases for more details.
 
-- 2026/02/17 (0.4) - Added ImPlot3DCol_AxisBg, ImPlot3DCol_AxisBgHovered, ImPlot3DCol_AxisBgActive colors for axis hover regions.
 - 2026/02/03 (0.4) - ImPlotSpec was made the default and _only_ way of styling plot items. The SetNextXXXStyle functions have been removed.
                       - SetNextLineStyle has been removed, styling should be set via ImPlot3DSpec.
                           ```cpp
@@ -628,7 +627,7 @@ ImVec2 ComputeEdgeOutwardDir(const ImVec2& p0, const ImVec2& p1, const ImVec2& b
 }
 
 // Forward declaration
-float ComputeMaxTickLabelExtent(const ImPlot3DAxis& axis, const ImVec2& axis_screen_dir);
+float ComputeMaxTickLabelExtent(const ImPlot3DAxis& axis);
 
 int GetMouseOverAxis(const ImPlot3DPlot& plot, const ImVec2* corners_pix, const int plane_2d, const int axis_corners[3][2], int* edge_out = nullptr) {
     const float tick_label_offset = 20.0f; // Base offset from axis to tick labels
@@ -683,22 +682,13 @@ int GetMouseOverAxis(const ImPlot3DPlot& plot, const ImVec2* corners_pix, const 
             axis_screen_dir = ImVec2(1.0f, 0.0f);
 
         // Compute hover rect width based on tick labels and axis label
-        float max_tick_extent = ComputeMaxTickLabelExtent(axis, axis_screen_dir);
+        float max_tick_extent = ComputeMaxTickLabelExtent(axis);
         float hover_width = tick_label_offset + max_tick_extent;
 
         // Add axis label extent if present
         if (axis.HasLabel()) {
-            float angle = atan2f(-axis_screen_dir.y, axis_screen_dir.x);
-            if (angle > IM_PI * 0.5f)
-                angle -= IM_PI;
-            if (angle < -IM_PI * 0.5f)
-                angle += IM_PI;
-
             ImVec2 label_size = ImGui::CalcTextSize(axis.GetLabel());
-            float cos_a = cosf(angle);
-            float sin_a = sinf(angle);
-            float label_extent = ImAbs(label_size.x * sin_a) + ImAbs(label_size.y * cos_a);
-            hover_width += axis_label_padding + label_extent * 0.5f + label_size.y * 0.5f;
+            hover_width += axis_label_padding + label_size.y * 0.5f;
         }
 
         ImVec2 p0 = corners_pix[idx0];
@@ -796,22 +786,13 @@ void RenderAxisRects(ImDrawList* draw_list, const ImPlot3DPlot& plot, const ImVe
             axis_screen_dir = ImVec2(1.0f, 0.0f);
 
         // Compute hover rect width based on tick labels and axis label
-        float max_tick_extent = ComputeMaxTickLabelExtent(axis, axis_screen_dir);
+        float max_tick_extent = ComputeMaxTickLabelExtent(axis);
         float hover_width = tick_label_offset + max_tick_extent;
 
         // Add axis label extent if present
         if (axis.HasLabel()) {
-            float angle = atan2f(-axis_screen_dir.y, axis_screen_dir.x);
-            if (angle > IM_PI * 0.5f)
-                angle -= IM_PI;
-            if (angle < -IM_PI * 0.5f)
-                angle += IM_PI;
-
             ImVec2 label_size = ImGui::CalcTextSize(axis.GetLabel());
-            float cos_a = cosf(angle);
-            float sin_a = sinf(angle);
-            float label_extent = ImAbs(label_size.x * sin_a) + ImAbs(label_size.y * cos_a);
-            hover_width += axis_label_padding + label_extent * 0.5f + label_size.y * 0.5f;
+            hover_width += axis_label_padding + label_size.y * 0.5f;
         }
 
         // Determine color based on state
@@ -1049,45 +1030,18 @@ void RenderTickMarks(ImDrawList* draw_list, const ImPlot3DPlot& plot, const ImPl
 }
 
 // Computes the maximum extent of tick labels perpendicular to the axis in screen space
-float ComputeMaxTickLabelExtent(const ImPlot3DAxis& axis, const ImVec2& axis_screen_dir) {
+float ComputeMaxTickLabelExtent(const ImPlot3DAxis& axis) {
     if (ImPlot3D::ImHasFlag(axis.Flags, ImPlot3DAxisFlags_NoTickLabels))
         return 0.0f;
 
-    // Compute angle perpendicular to axis in screen space
-    float angle = atan2f(-axis_screen_dir.y, axis_screen_dir.x) + IM_PI * 0.5f;
-
-    // Normalize angle to be between -π and π
-    if (angle > IM_PI)
-        angle -= 2 * IM_PI;
-    if (angle < -IM_PI)
-        angle += 2 * IM_PI;
-
-    // Adjust angle to keep labels upright
-    if (angle > IM_PI * 0.5f)
-        angle -= IM_PI;
-    if (angle < -IM_PI * 0.5f)
-        angle += IM_PI;
-
-    float cos_a = cosf(angle);
-    float sin_a = sinf(angle);
-
+    // Tick labels are always rendered perpendicular to the axis (in the outward direction),
+    // so LabelSize.x (the text advance width) fully contributes to the outward extent.
     float max_extent = 0.0f;
     for (int t = 0; t < axis.Ticker.TickCount(); ++t) {
         const ImPlot3DTick& tick = axis.Ticker.Ticks[t];
         if (!tick.ShowLabel)
             continue;
-
-        // The label is rendered centered at the tick position with rotation
-        // Compute the rotated bounding box extent perpendicular to the axis
-        float w = tick.LabelSize.x;
-        float h = tick.LabelSize.y;
-
-        // The extent perpendicular to the axis depends on the rotation
-        // For a rotated rectangle, the extent in the perpendicular direction is:
-        // |w * sin(angle)| + |h * cos(angle)| (half extent, since centered)
-        float extent = ImAbs(w * sin_a) + ImAbs(h * cos_a);
-        extent = extent * 0.5f + h * 0.5f; // Add half height for centering offset
-        max_extent = ImMax(max_extent, extent);
+        max_extent = ImMax(max_extent, tick.LabelSize.x * 0.5f);
     }
 
     return max_extent;
@@ -1140,8 +1094,8 @@ void RenderTickLabels(ImDrawList* draw_list, const ImPlot3DPlot& plot, const ImP
         if (ImDot(offset_dir_pix, center_to_axis_pix) < 0.0f)
             offset_dir_pix = -offset_dir_pix;
 
-        // Adjust the offset magnitude
-        float offset_magnitude = 20.0f; // TODO Calculate based on label size
+        // Offset tick labels from the axis edge (labels are centered at this distance)
+        float offset_magnitude = 20.0f;
         ImVec2 offset_pix = offset_dir_pix * offset_magnitude;
 
         // Compute angle perpendicular to axis in screen space
@@ -1233,7 +1187,7 @@ void RenderAxisLabels(ImDrawList* draw_list, const ImPlot3DPlot& plot, const ImP
             offset_dir_pix = -offset_dir_pix;
 
         // Compute max tick label extent
-        float max_tick_extent = ComputeMaxTickLabelExtent(axis, axis_screen_dir);
+        float max_tick_extent = ComputeMaxTickLabelExtent(axis);
 
         // Compute total offset: base offset + tick label extent + padding
         float total_offset = tick_label_offset + max_tick_extent + axis_label_padding;

--- a/implot3d.cpp
+++ b/implot3d.cpp
@@ -750,11 +750,12 @@ void RenderAxisRects(ImDrawList* draw_list, const ImPlot3DPlot& plot, const ImVe
         ImVec2 outward_dir = ComputeEdgeOutwardDir(p0, p1, box_center);
         float hover_width = ComputeAxisHoverWidth(axis);
 
-        // Determine color based on state
+        // Determine color based on state:
+        // Active only when the drag started on this axis rect (HeldEdgeIdx set), not on a plane or outside.
         ImU32 col;
-        if (axis.Held)
+        if (axis.Held && plot.HeldEdgeIdx != -1)
             col = axis.ColorAct;
-        else if (axis_idx == hovered_axis)
+        else if (axis_idx == hovered_axis && !plot.Held)
             col = axis.ColorHov;
         else
             col = axis.ColorBg;

--- a/implot3d.cpp
+++ b/implot3d.cpp
@@ -630,8 +630,8 @@ ImVec2 ComputeEdgeOutwardDir(const ImVec2& p0, const ImVec2& p1, const ImVec2& b
 float ComputeMaxTickLabelExtent(const ImPlot3DAxis& axis);
 
 int GetMouseOverAxis(const ImPlot3DPlot& plot, const ImVec2* corners_pix, const int plane_2d, const int axis_corners[3][2], int* edge_out = nullptr) {
-    const float tick_label_offset = 20.0f; // Base offset from axis to tick labels
-    const float axis_label_padding = 5.0f; // Padding between tick labels and axis label
+    const float inner_pad = 5.0f;
+    const float axis_label_padding = 5.0f;
 
     ImGuiIO& io = ImGui::GetIO();
     ImVec2 mouse_pos = io.MousePos;
@@ -683,7 +683,8 @@ int GetMouseOverAxis(const ImPlot3DPlot& plot, const ImVec2* corners_pix, const 
 
         // Compute hover rect width based on tick labels and axis label
         float max_tick_extent = ComputeMaxTickLabelExtent(axis);
-        float hover_width = tick_label_offset + max_tick_extent;
+        // hover width covers: inner_pad + 2*max_tick_extent (full tick label span)
+        float hover_width = max_tick_extent + inner_pad + max_tick_extent;
 
         // Add axis label extent if present
         if (axis.HasLabel()) {
@@ -733,8 +734,8 @@ void RenderPlotBackground(ImDrawList* draw_list, const ImPlot3DPlot& plot, const
 
 void RenderAxisRects(ImDrawList* draw_list, const ImPlot3DPlot& plot, const ImVec2* corners_pix, const bool*, const int plane_2d,
                      const int axis_corners[3][2]) {
-    const float tick_label_offset = 20.0f; // Base offset from axis to tick labels
-    const float axis_label_padding = 5.0f; // Padding between tick labels and axis label
+    const float inner_pad = 5.0f;
+    const float axis_label_padding = 5.0f;
 
     int hovered_edge = -1;
     if (!plot.Held)
@@ -787,7 +788,8 @@ void RenderAxisRects(ImDrawList* draw_list, const ImPlot3DPlot& plot, const ImVe
 
         // Compute hover rect width based on tick labels and axis label
         float max_tick_extent = ComputeMaxTickLabelExtent(axis);
-        float hover_width = tick_label_offset + max_tick_extent;
+        // hover width covers: inner_pad + 2*max_tick_extent (full tick label span)
+        float hover_width = max_tick_extent + inner_pad + max_tick_extent;
 
         // Add axis label extent if present
         if (axis.HasLabel()) {
@@ -1094,8 +1096,11 @@ void RenderTickLabels(ImDrawList* draw_list, const ImPlot3DPlot& plot, const ImP
         if (ImDot(offset_dir_pix, center_to_axis_pix) < 0.0f)
             offset_dir_pix = -offset_dir_pix;
 
-        // Offset tick labels from the axis edge (labels are centered at this distance)
-        float offset_magnitude = 20.0f;
+        // Offset tick labels from the axis edge: center labels so their inner edge
+        // (facing the box) clears the axis line by inner_pad pixels.
+        const float inner_pad = 5.0f;
+        float max_tick_extent = ComputeMaxTickLabelExtent(axis);
+        float offset_magnitude = max_tick_extent + inner_pad;
         ImVec2 offset_pix = offset_dir_pix * offset_magnitude;
 
         // Compute angle perpendicular to axis in screen space
@@ -1145,8 +1150,8 @@ void RenderTickLabels(ImDrawList* draw_list, const ImPlot3DPlot& plot, const ImP
 void RenderAxisLabels(ImDrawList* draw_list, const ImPlot3DPlot& plot, const ImPlot3DPoint*, const ImVec2* corners_pix,
                       const int axis_corners[3][2]) {
     ImU32 col_ax_txt = GetStyleColorU32(ImPlot3DCol_AxisText);
-    const float tick_label_offset = 20.0f; // Base offset from axis to tick labels
-    const float axis_label_padding = 5.0f; // Padding between tick labels and axis label
+    const float inner_pad = 5.0f;       // Gap from axis edge to inner edge of tick labels
+    const float axis_label_padding = 5.0f; // Gap between tick label outer edge and axis label center
 
     for (int a = 0; a < 3; a++) {
         const ImPlot3DAxis& axis = plot.Axes[a];
@@ -1186,11 +1191,12 @@ void RenderAxisLabels(ImDrawList* draw_list, const ImPlot3DPlot& plot, const ImP
         if (ImDot(offset_dir_pix, center_to_axis_pix) < 0.0f)
             offset_dir_pix = -offset_dir_pix;
 
-        // Compute max tick label extent
+        // Compute max tick label extent (half-width of the widest label)
         float max_tick_extent = ComputeMaxTickLabelExtent(axis);
 
-        // Compute total offset: base offset + tick label extent + padding
-        float total_offset = tick_label_offset + max_tick_extent + axis_label_padding;
+        // Tick label center is at (max_tick_extent + inner_pad) from the axis edge,
+        // so the axis label center is one more max_tick_extent + padding beyond that.
+        float total_offset = max_tick_extent + inner_pad + max_tick_extent + axis_label_padding;
 
         // Position the axis label at the center of the axis, offset by the computed amount
         ImVec2 label_pos_pix = axis_center_pix + offset_dir_pix * total_offset;

--- a/implot3d.cpp
+++ b/implot3d.cpp
@@ -630,8 +630,8 @@ ImVec2 ComputeEdgeOutwardDir(const ImVec2& p0, const ImVec2& p1, const ImVec2& b
 float ComputeMaxTickLabelExtent(const ImPlot3DAxis& axis);
 
 // Spacing constants for axis tick labels and axis labels
-static const float AXIS_TICK_INNER_PAD = 5.0f;   // gap between axis edge and inner edge of tick labels
-static const float AXIS_LABEL_PAD      = 10.0f;  // gap between tick label outer edge and axis label center
+static const float AXIS_TICK_INNER_PAD = 5.0f; // gap between axis edge and inner edge of tick labels
+static const float AXIS_LABEL_PAD = 10.0f;     // gap between tick label outer edge and axis label center
 
 // Computes the total outward width of the hover rect for an axis
 float ComputeAxisHoverWidth(const ImPlot3DAxis& axis) {
@@ -724,11 +724,7 @@ void RenderPlotBackground(ImDrawList* draw_list, const ImPlot3DPlot& plot, const
 
 void RenderAxisRects(ImDrawList* draw_list, const ImPlot3DPlot& plot, const ImVec2* corners_pix, const bool*, const int plane_2d,
                      const int axis_corners[3][2]) {
-    int hovered_edge = -1;
-    if (!plot.Held)
-        GetMouseOverAxis(plot, corners_pix, plane_2d, axis_corners, &hovered_edge);
-    else
-        hovered_edge = plot.HeldEdgeIdx;
+    int hovered_axis = GetMouseOverAxis(plot, corners_pix, plane_2d, axis_corners);
 
     // Compute box center in screen space
     ImVec2 box_center(0, 0);
@@ -745,20 +741,7 @@ void RenderAxisRects(ImDrawList* draw_list, const ImPlot3DPlot& plot, const ImVe
         int idx0 = axis_corners[axis_idx][0];
         int idx1 = axis_corners[axis_idx][1];
 
-        // Skip if axis corners are not defined
         if (idx0 == -1 || idx1 == -1)
-            continue;
-
-        // Find the edge index for these two corners
-        int edge = -1;
-        for (int e = 0; e < 12; e++) {
-            if ((edges[e][0] == idx0 && edges[e][1] == idx1) || (edges[e][0] == idx1 && edges[e][1] == idx0)) {
-                edge = e;
-                break;
-            }
-        }
-
-        if (edge == -1)
             continue;
 
         const ImPlot3DAxis& axis = plot.Axes[axis_idx];
@@ -769,15 +752,15 @@ void RenderAxisRects(ImDrawList* draw_list, const ImPlot3DPlot& plot, const ImVe
 
         // Determine color based on state
         ImU32 col;
-        if (edge == hovered_edge) {
-            col = axis.Held ? axis.ColorAct : axis.ColorHov;
-        } else {
+        if (axis.Held)
+            col = axis.ColorAct;
+        else if (axis_idx == hovered_axis)
+            col = axis.ColorHov;
+        else
             col = axis.ColorBg;
-        }
 
         // Draw hover rectangle if color is not transparent
         if (col != IM_COL32_BLACK_TRANS) {
-            // Draw rectangle extending outward from edge
             ImVec2 c0 = p0;
             ImVec2 c1 = p0 + outward_dir * hover_width;
             ImVec2 c2 = p1 + outward_dir * hover_width;

--- a/implot3d.cpp
+++ b/implot3d.cpp
@@ -629,10 +629,22 @@ ImVec2 ComputeEdgeOutwardDir(const ImVec2& p0, const ImVec2& p1, const ImVec2& b
 // Forward declaration
 float ComputeMaxTickLabelExtent(const ImPlot3DAxis& axis);
 
-int GetMouseOverAxis(const ImPlot3DPlot& plot, const ImVec2* corners_pix, const int plane_2d, const int axis_corners[3][2], int* edge_out = nullptr) {
-    const float inner_pad = 5.0f;
-    const float axis_label_padding = 10.0f;
+// Spacing constants for axis tick labels and axis labels
+static const float AXIS_TICK_INNER_PAD = 5.0f;   // gap between axis edge and inner edge of tick labels
+static const float AXIS_LABEL_PAD      = 10.0f;  // gap between tick label outer edge and axis label center
 
+// Computes the total outward width of the hover rect for an axis
+float ComputeAxisHoverWidth(const ImPlot3DAxis& axis) {
+    float max_tick_extent = ComputeMaxTickLabelExtent(axis);
+    float w = 2.0f * max_tick_extent + AXIS_TICK_INNER_PAD;
+    if (axis.HasLabel()) {
+        ImVec2 label_size = ImGui::CalcTextSize(axis.GetLabel());
+        w += AXIS_LABEL_PAD + label_size.y * 0.5f;
+    }
+    return w;
+}
+
+int GetMouseOverAxis(const ImPlot3DPlot& plot, const ImVec2* corners_pix, const int plane_2d, const int axis_corners[3][2], int* edge_out = nullptr) {
     ImGuiIO& io = ImGui::GetIO();
     ImVec2 mouse_pos = io.MousePos;
     if (edge_out)
@@ -669,32 +681,10 @@ int GetMouseOverAxis(const ImPlot3DPlot& plot, const ImVec2* corners_pix, const 
         if (edge == -1)
             continue;
 
-        const ImPlot3DAxis& axis = plot.Axes[axis_idx];
-
-        // Compute axis screen direction for tick label extent calculation
-        ImVec2 axis_start_pix = corners_pix[idx0];
-        ImVec2 axis_end_pix = corners_pix[idx1];
-        ImVec2 axis_screen_dir = axis_end_pix - axis_start_pix;
-        float axis_length = ImSqrt(ImLengthSqr(axis_screen_dir));
-        if (axis_length != 0.0f)
-            axis_screen_dir /= axis_length;
-        else
-            axis_screen_dir = ImVec2(1.0f, 0.0f);
-
-        // Compute hover rect width based on tick labels and axis label
-        float max_tick_extent = ComputeMaxTickLabelExtent(axis);
-        // hover width covers: inner_pad + 2*max_tick_extent (full tick label span)
-        float hover_width = max_tick_extent + inner_pad + max_tick_extent;
-
-        // Add axis label extent if present
-        if (axis.HasLabel()) {
-            ImVec2 label_size = ImGui::CalcTextSize(axis.GetLabel());
-            hover_width += axis_label_padding + label_size.y * 0.5f;
-        }
-
         ImVec2 p0 = corners_pix[idx0];
         ImVec2 p1 = corners_pix[idx1];
         ImVec2 outward_dir = ComputeEdgeOutwardDir(p0, p1, box_center);
+        float hover_width = ComputeAxisHoverWidth(plot.Axes[axis_idx]);
 
         // Check if mouse is within the edge's hover region
         if (IsPointInEdgeHoverRegion(mouse_pos, p0, p1, outward_dir, hover_width)) {
@@ -734,9 +724,6 @@ void RenderPlotBackground(ImDrawList* draw_list, const ImPlot3DPlot& plot, const
 
 void RenderAxisRects(ImDrawList* draw_list, const ImPlot3DPlot& plot, const ImVec2* corners_pix, const bool*, const int plane_2d,
                      const int axis_corners[3][2]) {
-    const float inner_pad = 5.0f;
-    const float axis_label_padding = 10.0f;
-
     int hovered_edge = -1;
     if (!plot.Held)
         GetMouseOverAxis(plot, corners_pix, plane_2d, axis_corners, &hovered_edge);
@@ -775,27 +762,10 @@ void RenderAxisRects(ImDrawList* draw_list, const ImPlot3DPlot& plot, const ImVe
             continue;
 
         const ImPlot3DAxis& axis = plot.Axes[axis_idx];
-
-        // Compute axis screen direction for tick label extent calculation
-        ImVec2 axis_start_pix = corners_pix[idx0];
-        ImVec2 axis_end_pix = corners_pix[idx1];
-        ImVec2 axis_screen_dir = axis_end_pix - axis_start_pix;
-        float axis_length = ImSqrt(ImLengthSqr(axis_screen_dir));
-        if (axis_length != 0.0f)
-            axis_screen_dir /= axis_length;
-        else
-            axis_screen_dir = ImVec2(1.0f, 0.0f);
-
-        // Compute hover rect width based on tick labels and axis label
-        float max_tick_extent = ComputeMaxTickLabelExtent(axis);
-        // hover width covers: inner_pad + 2*max_tick_extent (full tick label span)
-        float hover_width = max_tick_extent + inner_pad + max_tick_extent;
-
-        // Add axis label extent if present
-        if (axis.HasLabel()) {
-            ImVec2 label_size = ImGui::CalcTextSize(axis.GetLabel());
-            hover_width += axis_label_padding + label_size.y * 0.5f;
-        }
+        ImVec2 p0 = corners_pix[idx0];
+        ImVec2 p1 = corners_pix[idx1];
+        ImVec2 outward_dir = ComputeEdgeOutwardDir(p0, p1, box_center);
+        float hover_width = ComputeAxisHoverWidth(axis);
 
         // Determine color based on state
         ImU32 col;
@@ -807,10 +777,6 @@ void RenderAxisRects(ImDrawList* draw_list, const ImPlot3DPlot& plot, const ImVe
 
         // Draw hover rectangle if color is not transparent
         if (col != IM_COL32_BLACK_TRANS) {
-            ImVec2 p0 = corners_pix[idx0];
-            ImVec2 p1 = corners_pix[idx1];
-            ImVec2 outward_dir = ComputeEdgeOutwardDir(p0, p1, box_center);
-
             // Draw rectangle extending outward from edge
             ImVec2 c0 = p0;
             ImVec2 c1 = p0 + outward_dir * hover_width;
@@ -1066,42 +1032,21 @@ void RenderTickLabels(ImDrawList* draw_list, const ImPlot3DPlot& plot, const ImP
         if (idx0 == idx1)
             continue;
 
-        // Start and end points of the axis in plot space
+        // Start and end points of the axis in plot and screen space
         ImPlot3DPoint axis_start = corners[idx0];
-        ImPlot3DPoint axis_end = corners[idx1];
-
-        // Direction vector along the axis
-        ImPlot3DPoint axis_dir = axis_end - axis_start;
-
-        // Convert axis start and end to screen space
+        ImPlot3DPoint axis_dir = corners[idx1] - axis_start;
         ImVec2 axis_start_pix = corners_pix[idx0];
         ImVec2 axis_end_pix = corners_pix[idx1];
 
-        // Screen space axis direction
+        // Screen space axis direction (normalized), needed for text angle
         ImVec2 axis_screen_dir = axis_end_pix - axis_start_pix;
         float axis_length = ImSqrt(ImLengthSqr(axis_screen_dir));
-        if (axis_length != 0.0f)
-            axis_screen_dir /= axis_length;
-        else
-            axis_screen_dir = ImVec2(1.0f, 0.0f); // Default direction if length is zero
+        axis_screen_dir = (axis_length > 0.0f) ? axis_screen_dir / axis_length : ImVec2(1.0f, 0.0f);
 
-        // Perpendicular direction in screen space
-        ImVec2 offset_dir_pix = ImVec2(-axis_screen_dir.y, axis_screen_dir.x);
-
-        // Make sure direction points away from cube center
-        ImVec2 box_center_pix = PlotToPixels(plot.RangeCenter());
-        ImVec2 axis_center_pix = (axis_start_pix + axis_end_pix) * 0.5f;
-        ImVec2 center_to_axis_pix = axis_center_pix - box_center_pix;
-        center_to_axis_pix /= ImSqrt(ImLengthSqr(center_to_axis_pix));
-        if (ImDot(offset_dir_pix, center_to_axis_pix) < 0.0f)
-            offset_dir_pix = -offset_dir_pix;
-
-        // Offset tick labels from the axis edge: center labels so their inner edge
-        // (facing the box) clears the axis line by inner_pad pixels.
-        const float inner_pad = 5.0f;
+        // Outward perpendicular direction and label offset
+        ImVec2 outward_dir = ComputeEdgeOutwardDir(axis_start_pix, axis_end_pix, PlotToPixels(plot.RangeCenter()));
         float max_tick_extent = ComputeMaxTickLabelExtent(axis);
-        float offset_magnitude = max_tick_extent + inner_pad;
-        ImVec2 offset_pix = offset_dir_pix * offset_magnitude;
+        ImVec2 offset_pix = outward_dir * (max_tick_extent + AXIS_TICK_INNER_PAD);
 
         // Compute angle perpendicular to axis in screen space
         float angle = atan2f(-axis_screen_dir.y, axis_screen_dir.x) + IM_PI * 0.5f;
@@ -1150,8 +1095,6 @@ void RenderTickLabels(ImDrawList* draw_list, const ImPlot3DPlot& plot, const ImP
 void RenderAxisLabels(ImDrawList* draw_list, const ImPlot3DPlot& plot, const ImPlot3DPoint*, const ImVec2* corners_pix,
                       const int axis_corners[3][2]) {
     ImU32 col_ax_txt = GetStyleColorU32(ImPlot3DCol_AxisText);
-    const float inner_pad = 5.0f;       // Gap from axis edge to inner edge of tick labels
-    const float axis_label_padding = 10.0f; // Gap between tick label outer edge and axis label center
 
     for (int a = 0; a < 3; a++) {
         const ImPlot3DAxis& axis = plot.Axes[a];
@@ -1168,38 +1111,24 @@ void RenderAxisLabels(ImDrawList* draw_list, const ImPlot3DPlot& plot, const ImP
         if (idx0 == idx1)
             continue;
 
-        // Convert axis start and end to screen space
         ImVec2 axis_start_pix = corners_pix[idx0];
         ImVec2 axis_end_pix = corners_pix[idx1];
 
-        // Screen space axis direction
+        // Screen space axis direction (normalized), needed for text angle
         ImVec2 axis_screen_dir = axis_end_pix - axis_start_pix;
         float axis_length = ImSqrt(ImLengthSqr(axis_screen_dir));
-        if (axis_length != 0.0f)
-            axis_screen_dir /= axis_length;
-        else
-            axis_screen_dir = ImVec2(1.0f, 0.0f);
+        axis_screen_dir = (axis_length > 0.0f) ? axis_screen_dir / axis_length : ImVec2(1.0f, 0.0f);
 
-        // Perpendicular direction in screen space (pointing outward from plot center)
-        ImVec2 offset_dir_pix = ImVec2(-axis_screen_dir.y, axis_screen_dir.x);
-        ImVec2 box_center_pix = PlotToPixels(plot.RangeCenter());
-        ImVec2 axis_center_pix = (axis_start_pix + axis_end_pix) * 0.5f;
-        ImVec2 center_to_axis_pix = axis_center_pix - box_center_pix;
-        float center_dist = ImSqrt(ImLengthSqr(center_to_axis_pix));
-        if (center_dist > 0.0f)
-            center_to_axis_pix /= center_dist;
-        if (ImDot(offset_dir_pix, center_to_axis_pix) < 0.0f)
-            offset_dir_pix = -offset_dir_pix;
-
-        // Compute max tick label extent (half-width of the widest label)
+        // Outward perpendicular and total offset:
+        // tick labels are centered at (max_tick_extent + AXIS_TICK_INNER_PAD) from the axis edge,
+        // so the axis label sits one more max_tick_extent + AXIS_LABEL_PAD beyond that.
+        ImVec2 outward_dir = ComputeEdgeOutwardDir(axis_start_pix, axis_end_pix, PlotToPixels(plot.RangeCenter()));
         float max_tick_extent = ComputeMaxTickLabelExtent(axis);
+        float tick_label_center = max_tick_extent + AXIS_TICK_INNER_PAD;
+        float total_offset = tick_label_center + max_tick_extent + AXIS_LABEL_PAD;
 
-        // Tick label center is at (max_tick_extent + inner_pad) from the axis edge,
-        // so the axis label center is one more max_tick_extent + padding beyond that.
-        float total_offset = max_tick_extent + inner_pad + max_tick_extent + axis_label_padding;
-
-        // Position the axis label at the center of the axis, offset by the computed amount
-        ImVec2 label_pos_pix = axis_center_pix + offset_dir_pix * total_offset;
+        ImVec2 axis_center_pix = (axis_start_pix + axis_end_pix) * 0.5f;
+        ImVec2 label_pos_pix = axis_center_pix + outward_dir * total_offset;
 
         // Compute text angle
         float angle = atan2f(-axis_screen_dir.y, axis_screen_dir.x);

--- a/implot3d.cpp
+++ b/implot3d.cpp
@@ -630,8 +630,9 @@ ImVec2 ComputeEdgeOutwardDir(const ImVec2& p0, const ImVec2& p1, const ImVec2& b
 float ComputeMaxTickLabelExtent(const ImPlot3DAxis& axis);
 
 // Spacing constants for axis tick labels and axis labels
-static const float AXIS_TICK_INNER_PAD = 5.0f; // gap between axis edge and inner edge of tick labels
-static const float AXIS_LABEL_PAD = 10.0f;     // gap between tick label outer edge and axis label center
+static const float AXIS_TICK_INNER_PAD = 5.0f;  // gap between axis edge and inner edge of tick labels
+static const float AXIS_LABEL_PAD      = 10.0f; // gap between tick label outer edge and axis label center
+static const float AXIS_RECT_MIN_WIDTH = 40.0f; // minimum hover rect width when labels are absent
 
 // Computes the total outward width of the hover rect for an axis
 float ComputeAxisHoverWidth(const ImPlot3DAxis& axis) {
@@ -641,7 +642,7 @@ float ComputeAxisHoverWidth(const ImPlot3DAxis& axis) {
         ImVec2 label_size = ImGui::CalcTextSize(axis.GetLabel());
         w += AXIS_LABEL_PAD + label_size.y * 0.5f;
     }
-    return w;
+    return ImMax(w, AXIS_RECT_MIN_WIDTH);
 }
 
 int GetMouseOverAxis(const ImPlot3DPlot& plot, const ImVec2* corners_pix, const int plane_2d, const int axis_corners[3][2], int* edge_out = nullptr) {

--- a/implot3d.h
+++ b/implot3d.h
@@ -151,9 +151,12 @@ enum ImPlot3DCol_ {
     ImPlot3DCol_LegendBorder, // Legend border color
     ImPlot3DCol_LegendText,   // Legend text color
     // Axis colors
-    ImPlot3DCol_AxisText, // Axis label and tick lables color
-    ImPlot3DCol_AxisGrid, // Axis grid color
-    ImPlot3DCol_AxisTick, // Axis tick color (defaults to AxisGrid)
+    ImPlot3DCol_AxisText,      // Axis label and tick lables color
+    ImPlot3DCol_AxisGrid,      // Axis grid color
+    ImPlot3DCol_AxisTick,      // Axis tick color (defaults to AxisGrid)
+    ImPlot3DCol_AxisBg,        // Background color of axis hover region (defaults to transparent)
+    ImPlot3DCol_AxisBgHovered, // Axis hover color (defaults to ImGuiCol_ButtonHovered)
+    ImPlot3DCol_AxisBgActive,  // Axis active color (defaults to ImGuiCol_ButtonActive)
     ImPlot3DCol_COUNT,
 };
 

--- a/implot3d_internal.h
+++ b/implot3d_internal.h
@@ -488,6 +488,10 @@ struct ImPlot3DAxis {
     // User input
     bool Hovered;
     bool Held;
+    // Cached colors
+    ImU32 ColorBg;
+    ImU32 ColorHov;
+    ImU32 ColorAct;
 
     // Constructor
     ImPlot3DAxis() {
@@ -515,6 +519,8 @@ struct ImPlot3DAxis {
         // User input
         Hovered = false;
         Held = false;
+        // Cached colors
+        ColorBg = ColorHov = ColorAct = IM_COL32_BLACK_TRANS;
     }
 
     inline void Reset() {


### PR DESCRIPTION
Closes #98

This PR introduces an improvement to the axis interaction area as suggested by @epezent in #24
> For dragging/selecting/scrolling axes, I naturally want to hover the labels instead of the edge of the plot next to them. Consider making the label quad the widget, similar to ImPlot.

Before

https://github.com/user-attachments/assets/a21f6787-b85a-413f-80eb-56e384a46180


After

https://github.com/user-attachments/assets/7689f0f3-42c1-4334-98ca-cfb1977d945a

