### PR TITLE
Fixes warnings due to uninitialized class members

### DIFF
--- a/implot3d_items.cpp
+++ b/implot3d_items.cpp
@@ -752,8 +752,8 @@ template <class _Getter> struct RendererQuadImage : RendererBase {
 
 template <class _Getter> struct RendererSurfaceFill : RendererBase {
     RendererSurfaceFill(const _Getter& getter, int x_count, int y_count, ImU32 col, double scale_min, double scale_max)
-        : RendererBase((x_count - 1) * (y_count - 1), 6, 4), Getter(getter), XCount(x_count), YCount(y_count), Col(col), ScaleMin(scale_min),
-          ScaleMax(scale_max) {}
+        : RendererBase((x_count - 1) * (y_count - 1), 6, 4), Getter(getter), Min(0.), Max(0.), XCount(x_count), YCount(y_count), Col(col),
+          ScaleMin(scale_min), ScaleMax(scale_max) {}
 
     void Init(ImDrawList3D& draw_list_3d) const {
         UV = draw_list_3d._SharedData->TexUvWhitePixel;


### PR DESCRIPTION
With GCC 15.2.1, I recently encountered several warnings while building the project in my library related to the `Min` and `Max` members of `RendererSurfaceFill` not being initialized. I simply initialized these a zero in the constructor initializer list to silence the warnings, which shouldn't be any worse than leaving them uninitialized.