### PR TITLE
Fix: Cast loop variable to ImU32 in ImPlot3DColormapData to fix C4365 warning

### DIFF
--- a/implot3d_internal.h
+++ b/implot3d_internal.h
@@ -263,7 +263,7 @@ struct ImPlot3DColormapData {
                 for (int s = 0; s < 255; ++s) {
                     ImU32 a = keys[i];
                     ImU32 b = keys[i + 1];
-                    ImU32 c = ImPlot3D::ImMixU32(a, b, s);
+                    ImU32 c = ImPlot3D::ImMixU32(a, b, (ImU32)s);
                     // if (c != last) {
                     Tables.push_back(c);
                     // last = c;


### PR DESCRIPTION
### The build error
In implot3d_internal.h line 266, the for-loop counter s is declared as int but is passed directly to ImMixU32(ImU32, ImU32, ImU32), causing a C4365 signed/unsigned mismatch warning on MSVC. When warnings are treated as errors (e.g. /W4 /WX builds), this breaks compilation.
```
implot3d/implot3d_internal.h(266,56): error C2220: the following warning is treated as an error
                    ImU32 c = ImPlot3D::ImMixU32(a, b, s);
                                                       ^
implot3d/implot3d_internal.h(266,56): warning C4365: 'argument': conversion from 'int' to 'ImU32', signed/unsigned mismatch
```

### Fix (applied): Cast s to ImU32
Instead of suppressing this warning, I addressed the root cause in the code to ensure a more robust solution.

```
// Before
ImU32 c = ImPlot3D::ImMixU32(a, b, s);
// After
ImU32 c = ImPlot3D::ImMixU32(a, b, (ImU32)s);
```

### Alternative considered: Changing the loop variable itself to ImU32:
```
for (ImU32 s = 0; s < 255; ++s) {
```