### PR TITLE
Fix: Reorder GPlot3DStyleVarInfo array to match ImPlot3DStyleVar_ enum

### DIFF
--- a/implot3d.cpp
+++ b/implot3d.cpp
@@ -2778,18 +2778,18 @@ struct ImPlot3DStyleVarInfo {
 static const ImPlot3DStyleVarInfo GPlot3DStyleVarInfo[] = {
     // Item style
     {ImGuiDataType_Float, 1, (ImU32)offsetof(ImPlot3DStyle, LineWeight)}, // ImPlot3DStyleVar_LineWeight
-    {ImGuiDataType_S32, 1, (ImU32)offsetof(ImPlot3DStyle, Marker)},       // ImPlot3DStyleVar_Marker
+    {ImGuiDataType_S32,   1, (ImU32)offsetof(ImPlot3DStyle, Marker)},     // ImPlot3DStyleVar_Marker
     {ImGuiDataType_Float, 1, (ImU32)offsetof(ImPlot3DStyle, MarkerSize)}, // ImPlot3DStyleVar_MarkerSize
     {ImGuiDataType_Float, 1, (ImU32)offsetof(ImPlot3DStyle, FillAlpha)},  // ImPlot3DStyleVar_FillAlpha
 
     // Plot style
-    {ImGuiDataType_Float, 2, (ImU32)offsetof(ImPlot3DStyle, PlotDefaultSize)}, // ImPlot3DStyleVar_Plot3DDefaultSize
-    {ImGuiDataType_Float, 2, (ImU32)offsetof(ImPlot3DStyle, PlotMinSize)},     // ImPlot3DStyleVar_Plot3DMinSize
-    {ImGuiDataType_Float, 2, (ImU32)offsetof(ImPlot3DStyle, PlotPadding)},     // ImPlot3DStyleVar_Plot3DPadding
+    {ImGuiDataType_Float, 2, (ImU32)offsetof(ImPlot3DStyle, PlotDefaultSize)}, // ImPlot3DStyleVar_PlotDefaultSize
+    {ImGuiDataType_Float, 2, (ImU32)offsetof(ImPlot3DStyle, PlotMinSize)},     // ImPlot3DStyleVar_PlotMinSize
+    {ImGuiDataType_Float, 2, (ImU32)offsetof(ImPlot3DStyle, PlotPadding)},     // ImPlot3DStyleVar_PlotPadding
+    {ImGuiDataType_Float, 2, (ImU32)offsetof(ImPlot3DStyle, LabelPadding)},    // ImPlot3DStyleVar_LabelPadding
     {ImGuiDataType_Float, 1, (ImU32)offsetof(ImPlot3DStyle, ViewScaleFactor)}, // ImPlot3DStyleVar_ViewScaleFactor
 
-    // Label style
-    {ImGuiDataType_Float, 2, (ImU32)offsetof(ImPlot3DStyle, LabelPadding)},       // ImPlot3DStyleVar_LabelPaddine
+    // Legend style
     {ImGuiDataType_Float, 2, (ImU32)offsetof(ImPlot3DStyle, LegendPadding)},      // ImPlot3DStyleVar_LegendPadding
     {ImGuiDataType_Float, 2, (ImU32)offsetof(ImPlot3DStyle, LegendInnerPadding)}, // ImPlot3DStyleVar_LegendInnerPadding
     {ImGuiDataType_Float, 2, (ImU32)offsetof(ImPlot3DStyle, LegendSpacing)},      // ImPlot3DStyleVar_LegendSpacing


### PR DESCRIPTION
### The runtime error
The GPlot3DStyleVarInfo array in implot3d.cpp was out of sync with the ImPlot3DStyleVar_ enum declared in implot3d.h. LabelPadding was grouped under a misplaced // Label style section after ViewScaleFactor, whereas the enum defines it before ViewScaleFactor under // Plot style.

Since GetPlotStyleVarInfo indexes into the array directly by enum value, this mismatch would cause the wrong style field to be read/written at runtime.

<img width="1198" height="287" alt="image" src="https://github.com/user-attachments/assets/d451e525-a021-44b8-9d47-0d980ba68d00" />

<img width="1213" height="429" alt="image" src="https://github.com/user-attachments/assets/c847a9f3-f497-45c0-9348-5d53d363a967" />
<img width="1396" height="440" alt="image" src="https://github.com/user-attachments/assets/765dfe32-43d3-40f7-abb1-47a8078bc53d" />


### Changes
* Moved the LabelPadding entry in GPlot3DStyleVarInfo to before ViewScaleFactor, matching the enum order
* Corrected the trailing section comment from // Label style to // Legend style
* Fixed stale comment names ImPlot3DStyleVar_Plot3DDefaultSize/MinSize/Padding → ImPlot3DStyleVar_PlotDefaultSize/MinSize/Padding
* Fixed comment typo ImPlot3DStyleVar_LabelPaddine → ImPlot3DStyleVar_LabelPadding
* Minor comment alignment cleanup