### PR TITLE
Feat: OpenGL Backend

### DIFF
--- a/backends/implot3d_impl_opengl3.cpp
+++ b/backends/implot3d_impl_opengl3.cpp
@@ -367,13 +367,13 @@ void ImPlot3D_ImplOpenGL3_DestroyTexture(ImTextureID tex_id) {
     }
 }
 
-IMPLOT3D_IMPL_API void ImPlot3D_ImplOpenGL3_RenderPlots(ImPool<ImPlot3DPlot>* plots) {
-    if (!plots)
+IMPLOT3D_IMPL_API void ImPlot3D_ImplOpenGL3_RenderDrawData(ImDrawData3D* draw_data) {
+    if (!draw_data)
         return;
 
-    // Iterate through all plots
-    for (int i = 0; i < plots->GetBufSize(); i++) {
-        ImPlot3DPlot* plot = plots->GetByIndex(i);
+    // Iterate through all plots in the draw data
+    for (int i = 0; i < draw_data->Plots.Size; i++) {
+        ImPlot3DPlot* plot = draw_data->Plots[i];
         if (!plot || !plot->Initialized)
             continue;
 

--- a/backends/implot3d_impl_opengl3.cpp
+++ b/backends/implot3d_impl_opengl3.cpp
@@ -14,12 +14,12 @@
 // Track created textures for cleanup
 static ImVector<GLuint> g_CreatedTextures;
 
-IMPLOT3D_IMPL_API bool ImPlot3D_ImplOpenGL3_Init() {
+bool ImPlot3D_ImplOpenGL3_Init() {
     // TODO
     return true;
 }
 
-IMPLOT3D_IMPL_API void ImPlot3D_ImplOpenGL3_Shutdown() {
+void ImPlot3D_ImplOpenGL3_Shutdown() {
     // Clean up any remaining textures
     for (int i = 0; i < g_CreatedTextures.Size; i++) {
         glDeleteTextures(1, &g_CreatedTextures[i]);
@@ -27,7 +27,17 @@ IMPLOT3D_IMPL_API void ImPlot3D_ImplOpenGL3_Shutdown() {
     g_CreatedTextures.clear();
 }
 
-IMPLOT3D_IMPL_API ImTextureID ImPlot3D_ImplOpenGL3_CreateTexture(const ImVec2& size) {
+void ImPlot3D_ImplOpenGL3_RenderPlots(ImPool<ImPlot3DPlot>* plots) {
+    for (int i = 0; i < plots->GetBufSize(); i++) {
+        ImPlot3DPlot* plot = plots->GetByIndex(i);
+        // Create textures if they don't exist yet
+        if (plot->ColorTextureID == ImTextureID_Invalid) {
+            plot->ColorTextureID = ImPlot3D_ImplOpenGL3_CreateTexture(plot->PlotRect.GetSize());
+        }
+    }
+}
+
+ImTextureID ImPlot3D_ImplOpenGL3_CreateTexture(const ImVec2& size) {
     int width = (int)size.x;
     int height = (int)size.y;
 
@@ -113,7 +123,7 @@ IMPLOT3D_IMPL_API ImTextureID ImPlot3D_ImplOpenGL3_CreateTexture(const ImVec2& s
     return (ImTextureID)(intptr_t)texture_id;
 }
 
-IMPLOT3D_IMPL_API void ImPlot3D_ImplOpenGL3_DestroyTexture(ImTextureID tex_id) {
+void ImPlot3D_ImplOpenGL3_DestroyTexture(ImTextureID tex_id) {
     GLuint texture_id = (GLuint)(intptr_t)tex_id;
 
     if (texture_id != 0) {

--- a/backends/implot3d_impl_opengl3.cpp
+++ b/backends/implot3d_impl_opengl3.cpp
@@ -29,31 +29,11 @@
 #ifndef GL_COLOR_ATTACHMENT0
 #define GL_COLOR_ATTACHMENT0 0x8CE0
 #endif
-#ifndef GL_COLOR_ATTACHMENT1
-#define GL_COLOR_ATTACHMENT1 0x8CE1
-#endif
 #ifndef GL_DEPTH_ATTACHMENT
 #define GL_DEPTH_ATTACHMENT 0x8D00
 #endif
 #ifndef GL_DEPTH_BUFFER_BIT
 #define GL_DEPTH_BUFFER_BIT 0x00000100
-#endif
-
-// WBOIT texture format constants
-#ifndef GL_RGBA16F
-#define GL_RGBA16F 0x881A
-#endif
-#ifndef GL_R16F
-#define GL_R16F 0x822D
-#endif
-#ifndef GL_RED
-#define GL_RED 0x1903
-#endif
-#ifndef GL_COLOR
-#define GL_COLOR 0x1800
-#endif
-#ifndef GL_TEXTURE1
-#define GL_TEXTURE1 0x84C1
 #endif
 
 // Define depth test constants
@@ -77,8 +57,6 @@ typedef void(APIENTRYP PFNGLDEPTHMASKPROC)(GLboolean flag);
 typedef void(APIENTRYP PFNGLBLENDFUNCPROC)(GLenum sfactor, GLenum dfactor);
 typedef void(APIENTRYP PFNGLDRAWARRAYSPROC)(GLenum mode, GLint first, GLsizei count);
 typedef void(APIENTRYP PFNGLUNIFORM2FPROC)(GLint location, GLfloat v0, GLfloat v1);
-typedef void(APIENTRYP PFNGLDRAWBUFFERSPROC)(GLsizei n, const GLenum* bufs);
-typedef void(APIENTRYP PFNGLCLEARBUFFERFVPROC)(GLenum buffer, GLint drawbuffer, const GLfloat* value);
 
 static PFNGLGENFRAMEBUFFERSPROC glGenFramebuffers;
 static PFNGLDELETEFRAMEBUFFERSPROC glDeleteFramebuffers;
@@ -91,8 +69,6 @@ static PFNGLDEPTHMASKPROC glDepthMask;
 static PFNGLBLENDFUNCPROC glBlendFunc;
 static PFNGLDRAWARRAYSPROC glDrawArrays;
 static PFNGLUNIFORM2FPROC glUniform2f;
-static PFNGLDRAWBUFFERSPROC glDrawBuffers;
-static PFNGLCLEARBUFFERFVPROC glClearBufferfv;
 #endif
 
 // Shader sources
@@ -103,23 +79,26 @@ in vec3 Position;  // 3D NDC position (before rotation)
 in vec4 Color;     // RGBA color
 
 out vec4 Frag_Color;
-out float Frag_Depth;
 
 uniform mat4 u_Rotation;      // Rotation matrix from quaternion
 uniform vec2 u_ViewportSize;  // Viewport size (width, height) in pixels
 
 void main() {
+    // The input Position is in NDC space [-1, 1] before rotation
+    // NDCToPixels does: GetViewScale() * (Rotation * point)
+    // So we need to: 1) Apply rotation, 2) Apply aspect ratio correction
+
     // Apply rotation to the 3D NDC position
     vec4 rotated_pos = u_Rotation * vec4(Position, 1.0);
 
     // Calculate aspect ratio correction
-    float min_dim = min(u_ViewportSize.x, u_ViewportSize.y);
+    // GetViewScale uses min(width, height), so we need to scale the longer axis
+    float min_dim = min(u_ViewportSize.x, u_ViewportSize.y) * 1.11; // NOTE: No idea why 1.11 is needed
     vec2 scale = vec2(min_dim / u_ViewportSize.x, min_dim / u_ViewportSize.y);
 
     // Apply scale to maintain aspect ratio, flip Y, negate Z for depth
     gl_Position = vec4(rotated_pos.x * scale.x, -rotated_pos.y * scale.y, -rotated_pos.z, 1.0);
     Frag_Color = Color;
-    Frag_Depth = gl_Position.z;
 }
 )";
 
@@ -127,83 +106,27 @@ static const char* g_FragmentShaderSource = R"(
 #version 130
 
 in vec4 Frag_Color;
-in float Frag_Depth;
+out vec4 Out_Color;
 
 void main() {
+    // Apply sqrt to alpha for more natural transparency response
+    // This matches the visual behavior users expect and improves alpha blending quality
     vec4 color = Frag_Color;
-
-    // WBOIT weight function - simpler and more stable
-    // Using depth-based weight to help with ordering
-    float z = (Frag_Depth + 1.0) * 0.5; // Convert from [-1, 1] to [0, 1]
-    float weight = color.a * clamp(0.03 / (1e-5 + pow(z / 200.0, 4.0)), 1e-2, 3e3);
-
-    // Weighted color accumulation (to GL_COLOR_ATTACHMENT0)
-    // Note: weight already includes alpha, so don't multiply by color.a again
-    gl_FragData[0] = vec4(color.rgb * weight, weight);
-
-    // Reveal: accumulate alpha (to GL_COLOR_ATTACHMENT1)
-    gl_FragData[1] = vec4(color.a);
-}
-)";
-
-// Composite shader for WBOIT final pass
-static const char* g_CompositeVertexShaderSource = R"(
-#version 130
-
-in vec2 Position;
-in vec2 UV;
-
-out vec2 Frag_UV;
-
-void main() {
-    Frag_UV = UV;
-    gl_Position = vec4(Position * 1.11, 0.0, 1.0);
-}
-)";
-
-static const char* g_CompositeFragmentShaderSource = R"(
-#version 130
-
-in vec2 Frag_UV;
-
-uniform sampler2D u_AccumTexture;
-uniform sampler2D u_RevealTexture;
-
-void main() {
-    vec4 accum = texture2D(u_AccumTexture, Frag_UV);
-    float reveal = texture2D(u_RevealTexture, Frag_UV).r;
-
-    // Avoid division by zero
-    if (accum.a < 0.00001) {
-        discard;
-    }
-
-    // Average color from accumulated weighted colors
-    vec3 average_color = accum.rgb / accum.a;
-
-    // Use sqrt for more natural alpha response matching ImGui rendering
-    float alpha = sqrt(clamp(reveal, 0.0, 1.0));
-
-    gl_FragColor = vec4(average_color, alpha);
+    color.a = sqrt(color.a);
+    Out_Color = color;
 }
 )";
 
 // Backend data stored in ImPlot3D context
 struct ImPlot3D_ImplOpenGL3_Data {
     GLuint ShaderProgram;
-    GLuint CompositeShaderProgram;
     GLint AttribLocationPosition;
     GLint AttribLocationColor;
     GLint UniformLocationRotation;
     GLint UniformLocationViewportSize;
-    GLint CompositeAttribLocationPosition;
-    GLint CompositeAttribLocationUV;
-    GLint CompositeUniformLocationAccum;
-    GLint CompositeUniformLocationReveal;
     GLuint VBO;
     GLuint EBO; // Element buffer for indices
     GLuint VAO;
-    GLuint CompositeVAO;
     GLuint FBO;
 };
 static ImPlot3D_ImplOpenGL3_Data g_Data;
@@ -225,8 +148,6 @@ IMPLOT3D_IMPL_API bool ImPlot3D_ImplOpenGL3_Init() {
     glDepthFunc = (PFNGLDEPTHFUNCPROC)imgl3wGetProcAddress("glDepthFunc");
     glDrawArrays = (PFNGLDRAWARRAYSPROC)imgl3wGetProcAddress("glDrawArrays");
     glUniform2f = (PFNGLUNIFORM2FPROC)imgl3wGetProcAddress("glUniform2f");
-    glDrawBuffers = (PFNGLDRAWBUFFERSPROC)imgl3wGetProcAddress("glDrawBuffers");
-    glClearBufferfv = (PFNGLCLEARBUFFERFVPROC)imgl3wGetProcAddress("glClearBufferfv");
 #endif
 
     // Compile vertex shader
@@ -289,61 +210,6 @@ IMPLOT3D_IMPL_API bool ImPlot3D_ImplOpenGL3_Init() {
     g_Data.UniformLocationRotation = glGetUniformLocation(g_Data.ShaderProgram, "u_Rotation");
     g_Data.UniformLocationViewportSize = glGetUniformLocation(g_Data.ShaderProgram, "u_ViewportSize");
 
-    // Compile composite vertex shader for WBOIT
-    GLuint comp_vertex_shader = glCreateShader(GL_VERTEX_SHADER);
-    glShaderSource(comp_vertex_shader, 1, &g_CompositeVertexShaderSource, nullptr);
-    glCompileShader(comp_vertex_shader);
-
-    glGetShaderiv(comp_vertex_shader, GL_COMPILE_STATUS, &success);
-    if (!success) {
-        char info_log[512];
-        glGetShaderInfoLog(comp_vertex_shader, 512, nullptr, info_log);
-        IM_ASSERT_USER_ERROR(false, "ImPlot3D: Composite vertex shader compilation failed!");
-        IMGUI_DEBUG_PRINTF("ImPlot3D: Composite vertex shader error: %s\n", info_log);
-        return false;
-    }
-
-    // Compile composite fragment shader for WBOIT
-    GLuint comp_fragment_shader = glCreateShader(GL_FRAGMENT_SHADER);
-    glShaderSource(comp_fragment_shader, 1, &g_CompositeFragmentShaderSource, nullptr);
-    glCompileShader(comp_fragment_shader);
-
-    glGetShaderiv(comp_fragment_shader, GL_COMPILE_STATUS, &success);
-    if (!success) {
-        char info_log[512];
-        glGetShaderInfoLog(comp_fragment_shader, 512, nullptr, info_log);
-        IM_ASSERT_USER_ERROR(false, "ImPlot3D: Composite fragment shader compilation failed!");
-        IMGUI_DEBUG_PRINTF("ImPlot3D: Composite fragment shader error: %s\n", info_log);
-        glDeleteShader(comp_vertex_shader);
-        return false;
-    }
-
-    // Link composite shader program
-    g_Data.CompositeShaderProgram = glCreateProgram();
-    glAttachShader(g_Data.CompositeShaderProgram, comp_vertex_shader);
-    glAttachShader(g_Data.CompositeShaderProgram, comp_fragment_shader);
-    glLinkProgram(g_Data.CompositeShaderProgram);
-
-    glGetProgramiv(g_Data.CompositeShaderProgram, GL_LINK_STATUS, &success);
-    if (!success) {
-        char info_log[512];
-        glGetProgramInfoLog(g_Data.CompositeShaderProgram, 512, nullptr, info_log);
-        IM_ASSERT_USER_ERROR(false, "ImPlot3D: Composite shader linking failed!");
-        IMGUI_DEBUG_PRINTF("ImPlot3D: Composite shader linking error: %s\n", info_log);
-        glDeleteShader(comp_vertex_shader);
-        glDeleteShader(comp_fragment_shader);
-        return false;
-    }
-
-    glDeleteShader(comp_vertex_shader);
-    glDeleteShader(comp_fragment_shader);
-
-    // Get composite shader locations
-    g_Data.CompositeAttribLocationPosition = glGetAttribLocation(g_Data.CompositeShaderProgram, "Position");
-    g_Data.CompositeAttribLocationUV = glGetAttribLocation(g_Data.CompositeShaderProgram, "UV");
-    g_Data.CompositeUniformLocationAccum = glGetUniformLocation(g_Data.CompositeShaderProgram, "u_AccumTexture");
-    g_Data.CompositeUniformLocationReveal = glGetUniformLocation(g_Data.CompositeShaderProgram, "u_RevealTexture");
-
     // Create buffers
     glGenVertexArrays(1, &g_Data.VAO);
     glGenBuffers(1, &g_Data.VBO);
@@ -373,17 +239,6 @@ IMPLOT3D_IMPL_API bool ImPlot3D_ImplOpenGL3_Init() {
     glBindBuffer(GL_ARRAY_BUFFER, 0);
     glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
 
-    // Setup composite VAO for full-screen quad
-    glGenVertexArrays(1, &g_Data.CompositeVAO);
-    glBindVertexArray(g_Data.CompositeVAO);
-
-    // Note: Composite VAO doesn't need buffers bound yet - they'll be set during rendering
-    // Just configure attribute locations for when we do bind them
-    glEnableVertexAttribArray(g_Data.CompositeAttribLocationPosition);
-    glEnableVertexAttribArray(g_Data.CompositeAttribLocationUV);
-
-    glBindVertexArray(0);
-
     // Create FBO for offscreen rendering
     glGenFramebuffers(1, &g_Data.FBO);
 
@@ -394,12 +249,8 @@ IMPLOT3D_IMPL_API void ImPlot3D_ImplOpenGL3_Shutdown() {
     // Delete OpenGL resources
     if (g_Data.ShaderProgram)
         glDeleteProgram(g_Data.ShaderProgram);
-    if (g_Data.CompositeShaderProgram)
-        glDeleteProgram(g_Data.CompositeShaderProgram);
     if (g_Data.VAO)
         glDeleteVertexArrays(1, &g_Data.VAO);
-    if (g_Data.CompositeVAO)
-        glDeleteVertexArrays(1, &g_Data.CompositeVAO);
     if (g_Data.VBO)
         glDeleteBuffers(1, &g_Data.VBO);
     if (g_Data.EBO)
@@ -417,14 +268,26 @@ IMPLOT3D_IMPL_API void ImPlot3D_ImplOpenGL3_Shutdown() {
     g_Data = ImPlot3D_ImplOpenGL3_Data();
 }
 
-// Generic texture creation function
-static ImTextureID CreateTexture(const ImVec2& size, GLint internalFormat, GLenum format, GLenum type, GLint minFilter, GLint magFilter) {
+ImTextureID ImPlot3D_ImplOpenGL3_CreateRGBATexture(const ImVec2& size) {
     int width = (int)size.x;
     int height = (int)size.y;
 
+    // Use ImGui's error handling for user-facing errors
+    IM_ASSERT_USER_ERROR(width > 0 && height > 0, "ImPlot3D_ImplOpenGL3_CreateTexture: size must be positive!");
     if (width <= 0 || height <= 0)
         return ImTextureID_Invalid;
 
+    // Create rainbow gradient pixel data (RGBA)
+    size_t pixel_count = (size_t)width * (size_t)height;
+    size_t data_size = pixel_count * 4; // 4 bytes per pixel (RGBA)
+
+    // Allocate using ImGui's allocation
+    unsigned char* pixels = (unsigned char*)IM_ALLOC(data_size);
+
+    // Fill with zeros (transparent black)
+    memset(pixels, 0, data_size);
+
+    // Generate OpenGL texture
     GLuint texture_id = 0;
     GLint last_texture = 0;
     glGetIntegerv(GL_TEXTURE_BINDING_2D, &last_texture);
@@ -432,27 +295,64 @@ static ImTextureID CreateTexture(const ImVec2& size, GLint internalFormat, GLenu
     glGenTextures(1, &texture_id);
     glBindTexture(GL_TEXTURE_2D, texture_id);
 
-    glTexImage2D(GL_TEXTURE_2D, 0, internalFormat, width, height, 0, format, type, nullptr);
-
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, minFilter);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, magFilter);
+    // Set texture parameters
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 
+    // Upload pixel data to GPU
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, pixels);
+
+    // Free CPU memory
+    IM_FREE(pixels);
+
+    // Restore previous texture binding
     glBindTexture(GL_TEXTURE_2D, last_texture);
 
+    // Track this texture for cleanup
     g_CreatedTextures.push_back(texture_id);
+
+    // Return as ImTextureID (cast GLuint to ImTextureID)
     return (ImTextureID)(intptr_t)texture_id;
 }
 
-ImTextureID ImPlot3D_ImplOpenGL3_CreateRGBATexture(const ImVec2& size) {
-    IM_ASSERT_USER_ERROR(size.x > 0 && size.y > 0, "ImPlot3D_ImplOpenGL3_CreateTexture: size must be positive!");
-    return CreateTexture(size, GL_RGBA, GL_RGBA, GL_UNSIGNED_BYTE, GL_LINEAR, GL_LINEAR);
-}
-
 IMPLOT3D_IMPL_API ImTextureID ImPlot3D_ImplOpenGL3_CreateDepthTexture(const ImVec2& size) {
-    IM_ASSERT_USER_ERROR(size.x > 0 && size.y > 0, "ImPlot3D_ImplOpenGL3_CreateDepthTexture: size must be positive!");
-    return CreateTexture(size, GL_DEPTH_COMPONENT24, GL_DEPTH_COMPONENT, GL_UNSIGNED_INT, GL_NEAREST, GL_NEAREST);
+    int width = (int)size.x;
+    int height = (int)size.y;
+
+    // Use ImGui's error handling for user-facing errors
+    IM_ASSERT_USER_ERROR(width > 0 && height > 0, "ImPlot3D_ImplOpenGL3_CreateDepthTexture: size must be positive!");
+    if (width <= 0 || height <= 0)
+        return ImTextureID_Invalid;
+
+    // Generate OpenGL depth texture
+    GLuint texture_id = 0;
+    GLint last_texture = 0;
+    glGetIntegerv(GL_TEXTURE_BINDING_2D, &last_texture);
+
+    glGenTextures(1, &texture_id);
+    glBindTexture(GL_TEXTURE_2D, texture_id);
+
+    // Create depth texture
+    // GL_DEPTH_COMPONENT24: 24-bit depth precision (good balance of precision and memory)
+    // Note: ImPlot3D targets OpenGL 3.0+ where depth textures are core
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT24, width, height, 0, GL_DEPTH_COMPONENT, GL_UNSIGNED_INT, nullptr);
+
+    // Set texture parameters (recommended for depth textures)
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST); // No interpolation for depth
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE); // Clamp to avoid edge artifacts
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+
+    // Restore previous texture binding
+    glBindTexture(GL_TEXTURE_2D, last_texture);
+
+    // Track this texture for cleanup
+    g_CreatedTextures.push_back(texture_id);
+
+    // Return as ImTextureID (cast GLuint to ImTextureID)
+    return (ImTextureID)(intptr_t)texture_id;
 }
 
 void ImPlot3D_ImplOpenGL3_DestroyTexture(ImTextureID tex_id) {
@@ -471,16 +371,6 @@ void ImPlot3D_ImplOpenGL3_DestroyTexture(ImTextureID tex_id) {
     }
 }
 
-// Create WBOIT accumulation texture (RGBA16F)
-ImTextureID ImPlot3D_ImplOpenGL3_CreateAccumTexture(const ImVec2& size) {
-    return CreateTexture(size, GL_RGBA16F, GL_RGBA, GL_FLOAT, GL_LINEAR, GL_LINEAR);
-}
-
-// Create WBOIT reveal texture (R16F)
-ImTextureID ImPlot3D_ImplOpenGL3_CreateRevealTexture(const ImVec2& size) {
-    return CreateTexture(size, GL_R16F, GL_RED, GL_FLOAT, GL_LINEAR, GL_LINEAR);
-}
-
 IMPLOT3D_IMPL_API void ImPlot3D_ImplOpenGL3_RenderDrawData(ImDrawData3D* draw_data) {
     if (!draw_data)
         return;
@@ -495,12 +385,6 @@ IMPLOT3D_IMPL_API void ImPlot3D_ImplOpenGL3_RenderDrawData(ImDrawData3D* draw_da
             }
             if (plot_data->DepthTextureID != ImTextureID_Invalid) {
                 ImPlot3D_ImplOpenGL3_DestroyTexture(plot_data->DepthTextureID);
-            }
-            if (plot_data->AccumTextureID != ImTextureID_Invalid) {
-                ImPlot3D_ImplOpenGL3_DestroyTexture(plot_data->AccumTextureID);
-            }
-            if (plot_data->RevealTextureID != ImTextureID_Invalid) {
-                ImPlot3D_ImplOpenGL3_DestroyTexture(plot_data->RevealTextureID);
             }
             // Remove from array
             draw_data->PlotData.erase(draw_data->PlotData.Data + i);
@@ -524,72 +408,35 @@ IMPLOT3D_IMPL_API void ImPlot3D_ImplOpenGL3_RenderDrawData(ImDrawData3D* draw_da
                 ImPlot3D_ImplOpenGL3_DestroyTexture(plot_data->DepthTextureID);
                 plot_data->DepthTextureID = ImTextureID_Invalid;
             }
-            if (plot_data->AccumTextureID != ImTextureID_Invalid) {
-                ImPlot3D_ImplOpenGL3_DestroyTexture(plot_data->AccumTextureID);
-                plot_data->AccumTextureID = ImTextureID_Invalid;
-            }
-            if (plot_data->RevealTextureID != ImTextureID_Invalid) {
-                ImPlot3D_ImplOpenGL3_DestroyTexture(plot_data->RevealTextureID);
-                plot_data->RevealTextureID = ImTextureID_Invalid;
-            }
 
             // Create new textures with current size
             plot_data->ColorTextureID = ImPlot3D_ImplOpenGL3_CreateRGBATexture(plot_data->TextureSize);
             plot_data->DepthTextureID = ImPlot3D_ImplOpenGL3_CreateDepthTexture(plot_data->TextureSize);
-            plot_data->AccumTextureID = ImPlot3D_ImplOpenGL3_CreateAccumTexture(plot_data->TextureSize);
-            plot_data->RevealTextureID = ImPlot3D_ImplOpenGL3_CreateRevealTexture(plot_data->TextureSize);
         }
 
         // Get texture IDs
         GLuint color_texture = (GLuint)(intptr_t)plot_data->ColorTextureID;
         GLuint depth_texture = (GLuint)(intptr_t)plot_data->DepthTextureID;
-        GLuint accum_texture = (GLuint)(intptr_t)plot_data->AccumTextureID;
-        GLuint reveal_texture = (GLuint)(intptr_t)plot_data->RevealTextureID;
-        if (color_texture == 0 || accum_texture == 0 || reveal_texture == 0)
+        if (color_texture == 0)
             continue;
 
         // Skip if no vertices to render
         if (plot_data->VtxBuffer.Size == 0 || plot_data->IdxBuffer.Size == 0)
             continue;
 
-        // Convert vertices from double to float for OpenGL 3.x compatibility
-        struct GLVertex {
-            float x, y, z;
-            ImU32 col;
-        };
-
-        ImVector<GLVertex> gl_vertices;
-        gl_vertices.resize(plot_data->VtxBuffer.Size);
-        for (int v = 0; v < plot_data->VtxBuffer.Size; v++) {
-            const ImDrawVert3D& src = plot_data->VtxBuffer.Data[v];
-            GLVertex& dst = gl_vertices.Data[v];
-            dst.x = (float)src.pos.x;
-            dst.y = (float)src.pos.y;
-            dst.z = (float)src.pos.z;
-            dst.col = src.col;
-        }
-
-        // ====================
-        // WBOIT Pass 1: Render geometry to accum/reveal targets
-        // ====================
-
+        // Bind framebuffer
         glBindFramebuffer(GL_FRAMEBUFFER, g_Data.FBO);
 
-        // Attach accum and reveal textures as color attachments
-        glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, accum_texture, 0);
-        glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT1, GL_TEXTURE_2D, reveal_texture, 0);
+        // Attach textures to framebuffer
+        glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, color_texture, 0);
         if (depth_texture != 0) {
             glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, depth_texture, 0);
         }
 
-        // Specify which color attachments to draw to
-        GLenum draw_buffers[2] = {GL_COLOR_ATTACHMENT0, GL_COLOR_ATTACHMENT1};
-        glDrawBuffers(2, draw_buffers);
-
         // Check framebuffer status
         GLenum status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
         if (status != GL_FRAMEBUFFER_COMPLETE) {
-            IMGUI_DEBUG_PRINTF("ImPlot3D: WBOIT framebuffer not complete! Status: 0x%x\n", status);
+            IMGUI_DEBUG_PRINTF("ImPlot3D: Framebuffer not complete! Status: 0x%x\n", status);
             glBindFramebuffer(GL_FRAMEBUFFER, 0);
             continue;
         }
@@ -597,32 +444,30 @@ IMPLOT3D_IMPL_API void ImPlot3D_ImplOpenGL3_RenderDrawData(ImDrawData3D* draw_da
         // Set viewport to texture size
         glViewport(0, 0, (int)plot_data->GetPlotWidth(), (int)plot_data->GetPlotHeight());
 
-        // Clear accum to (0,0,0,0) and reveal to 0.0
+        // Clear color and depth
         glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
-        glClearDepth(1.0);
+        glClearDepth(1.0); // Clear depth to far plane
         glClear(GL_COLOR_BUFFER_BIT | (depth_texture != 0 ? GL_DEPTH_BUFFER_BIT : 0));
 
-        // For reveal texture (attachment 1), clear to 0.0 (we're accumulating alpha)
-        GLfloat clear_reveal[4] = {0.0f, 0.0f, 0.0f, 0.0f};
-        glClearBufferfv(GL_COLOR, 1, clear_reveal);
-
-        // Enable depth testing but disable depth writes (WBOIT requirement)
+        // Enable depth testing
         if (depth_texture != 0) {
             glEnable(GL_DEPTH_TEST);
-            glDepthFunc(GL_LESS);
-            glDepthMask(GL_FALSE); // Disable depth writes for WBOIT
+            glDepthFunc(GL_LESS); // Closer = smaller Z after negation
+            glDepthMask(GL_TRUE); // Enable depth writes
         }
 
-        // Enable additive blending for WBOIT
+        // Enable alpha blending (same as ImGui's OpenGL3 backend)
         glEnable(GL_BLEND);
-        glBlendFunc(GL_ONE, GL_ONE); // Additive blending
+        glBlendEquation(GL_FUNC_ADD);
+        glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
 
-        // Use WBOIT geometry shader
+        // Use shader program
         glUseProgram(g_Data.ShaderProgram);
 
         // Convert quaternion to rotation matrix and upload to shader
         ImPlot3DQuat rot = plot_data->Rotation;
         float rot_matrix[16];
+        // Quaternion to matrix conversion (column-major for OpenGL)
         float xx = (float)(rot.x * rot.x);
         float yy = (float)(rot.y * rot.y);
         float zz = (float)(rot.z * rot.z);
@@ -654,95 +499,49 @@ IMPLOT3D_IMPL_API void ImPlot3D_ImplOpenGL3_RenderDrawData(ImDrawData3D* draw_da
         rot_matrix[15] = 1.0f;
 
         glUniformMatrix4fv(g_Data.UniformLocationRotation, 1, GL_FALSE, rot_matrix);
+
+        // Upload viewport size uniform
         glUniform2f(g_Data.UniformLocationViewportSize, plot_data->GetPlotWidth(), plot_data->GetPlotHeight());
 
-        // Bind VAO and upload vertex/index data
+        // Convert vertices from double to float for OpenGL 3.x compatibility
+        struct GLVertex {
+            float x, y, z;
+            ImU32 col;
+        };
+
+        ImVector<GLVertex> gl_vertices;
+        gl_vertices.resize(plot_data->VtxBuffer.Size);
+        for (int v = 0; v < plot_data->VtxBuffer.Size; v++) {
+            const ImDrawVert3D& src = plot_data->VtxBuffer.Data[v];
+            GLVertex& dst = gl_vertices.Data[v];
+            dst.x = (float)src.pos.x;
+            dst.y = (float)src.pos.y;
+            dst.z = (float)src.pos.z;
+            dst.col = src.col;
+        }
+
+        // Bind VAO (this restores all the vertex attribute configuration from Init)
         glBindVertexArray(g_Data.VAO);
+
+        // Bind and upload vertex data to VBO
         glBindBuffer(GL_ARRAY_BUFFER, g_Data.VBO);
         glBufferData(GL_ARRAY_BUFFER, gl_vertices.Size * sizeof(GLVertex), gl_vertices.Data, GL_STREAM_DRAW);
+
+        // Bind and upload index data to EBO
         glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, g_Data.EBO);
         glBufferData(GL_ELEMENT_ARRAY_BUFFER, plot_data->IdxBuffer.Size * sizeof(ImDrawIdx3D), plot_data->IdxBuffer.Data, GL_STREAM_DRAW);
 
-        // Draw triangles to accum/reveal
+        // Draw triangles
         glDrawElements(GL_TRIANGLES, plot_data->IdxBuffer.Size, GL_UNSIGNED_INT, nullptr);
 
-        glBindVertexArray(0);
-        glUseProgram(0);
-
-        // ====================
-        // WBOIT Pass 2: Composite pass to final color texture
-        // ====================
-
-        // Attach final color texture as output
-        glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, color_texture, 0);
-        glDrawBuffers(1, draw_buffers); // Only draw to color attachment 0 now
-
-        // Clear final color to transparent
-        glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
-        glClear(GL_COLOR_BUFFER_BIT);
-
-        // Disable depth test for composite pass (full-screen quad)
-        glDisable(GL_DEPTH_TEST);
-
-        // Use standard alpha blending for final composite
-        glBlendEquation(GL_FUNC_ADD);
-        glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
-
-        // Use composite shader
-        glUseProgram(g_Data.CompositeShaderProgram);
-
-        // Bind accum and reveal textures
-        glActiveTexture(GL_TEXTURE0);
-        glBindTexture(GL_TEXTURE_2D, accum_texture);
-        glUniform1i(g_Data.CompositeUniformLocationAccum, 0);
-
-        glActiveTexture(GL_TEXTURE1);
-        glBindTexture(GL_TEXTURE_2D, reveal_texture);
-        glUniform1i(g_Data.CompositeUniformLocationReveal, 1);
-
-        // Draw full-screen quad
-        // Define quad vertices: position (XY in NDC) + UV
-        float quad_vertices[] = {
-            // X     Y     U    V
-            -1.0f, -1.0f, 0.0f, 0.0f, // Bottom-left
-            1.0f,  -1.0f, 1.0f, 0.0f, // Bottom-right
-            1.0f,  1.0f,  1.0f, 1.0f, // Top-right
-            -1.0f, 1.0f,  0.0f, 1.0f  // Top-left
-        };
-        unsigned int quad_indices[] = {0, 1, 2, 0, 2, 3};
-
-        glBindVertexArray(g_Data.CompositeVAO);
-
-        // Upload quad vertices (position + UV)
-        GLuint quad_vbo;
-        glGenBuffers(1, &quad_vbo);
-        glBindBuffer(GL_ARRAY_BUFFER, quad_vbo);
-        glBufferData(GL_ARRAY_BUFFER, sizeof(quad_vertices), quad_vertices, GL_STREAM_DRAW);
-
-        // Configure attributes
-        glVertexAttribPointer(g_Data.CompositeAttribLocationPosition, 2, GL_FLOAT, GL_FALSE, 4 * sizeof(float), (void*)0);
-        glVertexAttribPointer(g_Data.CompositeAttribLocationUV, 2, GL_FLOAT, GL_FALSE, 4 * sizeof(float), (void*)(2 * sizeof(float)));
-
-        // Upload quad indices
-        GLuint quad_ebo;
-        glGenBuffers(1, &quad_ebo);
-        glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, quad_ebo);
-        glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(quad_indices), quad_indices, GL_STREAM_DRAW);
-
-        // Draw quad
-        glDrawElements(GL_TRIANGLES, 6, GL_UNSIGNED_INT, nullptr);
-
-        // Cleanup temporary buffers
-        glDeleteBuffers(1, &quad_vbo);
-        glDeleteBuffers(1, &quad_ebo);
-
+        // Unbind VAO
         glBindVertexArray(0);
         glUseProgram(0);
 
         // Disable states
         glDisable(GL_BLEND);
         if (depth_texture != 0) {
-            glDepthMask(GL_TRUE); // Re-enable depth writes
+            glDisable(GL_DEPTH_TEST);
         }
     }
 

--- a/backends/implot3d_impl_opengl3.cpp
+++ b/backends/implot3d_impl_opengl3.cpp
@@ -563,8 +563,16 @@ IMPLOT3D_IMPL_API void ImPlot3D_ImplOpenGL3_RenderDrawData(ImDrawData3D* draw_da
         glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, g_Data.EBO);
         glBufferData(GL_ELEMENT_ARRAY_BUFFER, plot_data->IdxBuffer.Size * sizeof(ImDrawIdx3D), plot_data->IdxBuffer.Data, GL_STREAM_DRAW);
 
-        // Draw triangles
-        glDrawElements(GL_TRIANGLES, plot_data->IdxBuffer.Size, GL_UNSIGNED_INT, nullptr);
+        // Draw primitives using command buffer
+        for (int cmd_i = 0; cmd_i < plot_data->CmdBuffer.Size; cmd_i++) {
+            const ImDrawCmd3D& cmd = plot_data->CmdBuffer[cmd_i];
+
+            // Phase 3: Assert all commands are triangles (line support comes in Phase 6)
+            IM_ASSERT(cmd.Type == ImDrawCmd3DType_Triangles && "Phase 3: Only triangle commands supported");
+
+            // Draw triangles for this command
+            glDrawElements(GL_TRIANGLES, cmd.IdxCount, GL_UNSIGNED_INT, (void*)(cmd.IdxOffset * sizeof(ImDrawIdx3D)));
+        }
 
         // Unbind VAO
         glBindVertexArray(0);

--- a/backends/implot3d_impl_opengl3.cpp
+++ b/backends/implot3d_impl_opengl3.cpp
@@ -19,20 +19,182 @@
 #define GL_DEPTH_COMPONENT24 0x81A6
 #endif
 
+// Define framebuffer constants if not present in ImGui's stripped loader
+#ifndef GL_FRAMEBUFFER
+#define GL_FRAMEBUFFER 0x8D40
+#endif
+#ifndef GL_FRAMEBUFFER_COMPLETE
+#define GL_FRAMEBUFFER_COMPLETE 0x8CD5
+#endif
+#ifndef GL_COLOR_ATTACHMENT0
+#define GL_COLOR_ATTACHMENT0 0x8CE0
+#endif
+#ifndef GL_DEPTH_ATTACHMENT
+#define GL_DEPTH_ATTACHMENT 0x8D00
+#endif
+#ifndef GL_DEPTH_BUFFER_BIT
+#define GL_DEPTH_BUFFER_BIT 0x00000100
+#endif
+
+// Declare framebuffer functions if not in stripped loader
+#ifndef IMGUI_IMPL_OPENGL_ES2
+extern "C" {
+typedef void (APIENTRYP PFNGLGENFRAMEBUFFERSPROC)(GLsizei n, GLuint* framebuffers);
+typedef void (APIENTRYP PFNGLDELETEFRAMEBUFFERSPROC)(GLsizei n, const GLuint* framebuffers);
+typedef void (APIENTRYP PFNGLBINDFRAMEBUFFERPROC)(GLenum target, GLuint framebuffer);
+typedef void (APIENTRYP PFNGLFRAMEBUFFERTEXTURE2DPROC)(GLenum target, GLenum attachment, GLenum textarget, GLuint texture, GLint level);
+typedef GLenum (APIENTRYP PFNGLCHECKFRAMEBUFFERSTATUSPROC)(GLenum target);
+typedef void (APIENTRYP PFNGLDRAWARRAYSPROC)(GLenum mode, GLint first, GLsizei count);
+
+static PFNGLGENFRAMEBUFFERSPROC glGenFramebuffers;
+static PFNGLDELETEFRAMEBUFFERSPROC glDeleteFramebuffers;
+static PFNGLBINDFRAMEBUFFERPROC glBindFramebuffer;
+static PFNGLFRAMEBUFFERTEXTURE2DPROC glFramebufferTexture2D;
+static PFNGLCHECKFRAMEBUFFERSTATUSPROC glCheckFramebufferStatus;
+static PFNGLDRAWARRAYSPROC glDrawArrays;
+}
+#endif
+
+// Shader sources
+static const char* g_VertexShaderSource = R"(
+#version 130
+
+in vec3 Position;
+in vec4 Color;
+
+out vec4 Frag_Color;
+
+void main() {
+    // Simple orthographic projection: use X and Y, ignore Z for now
+    gl_Position = vec4(Position.x, Position.y, 0.0, 1.0);
+    Frag_Color = Color;
+}
+)";
+
+static const char* g_FragmentShaderSource = R"(
+#version 130
+
+in vec4 Frag_Color;
+out vec4 Out_Color;
+
+void main() {
+    Out_Color = Frag_Color;
+}
+)";
+
+// Backend data stored in ImPlot3D context
+struct ImPlot3D_ImplOpenGL3_Data {
+    GLuint ShaderProgram;
+    GLint AttribLocationPosition;
+    GLint AttribLocationColor;
+    GLuint VBO;
+    GLuint VAO;
+    GLuint FBO;
+};
+static ImPlot3D_ImplOpenGL3_Data g_Data;
+
 // Track created textures for cleanup
 static ImVector<GLuint> g_CreatedTextures;
 
-bool ImPlot3D_ImplOpenGL3_Init() {
-    // TODO
+
+IMPLOT3D_IMPL_API bool ImPlot3D_ImplOpenGL3_Init() {
+    // Load framebuffer functions (not in stripped loader)
+#ifndef IMGUI_IMPL_OPENGL_ES2
+    glGenFramebuffers = (PFNGLGENFRAMEBUFFERSPROC)imgl3wGetProcAddress("glGenFramebuffers");
+    glDeleteFramebuffers = (PFNGLDELETEFRAMEBUFFERSPROC)imgl3wGetProcAddress("glDeleteFramebuffers");
+    glBindFramebuffer = (PFNGLBINDFRAMEBUFFERPROC)imgl3wGetProcAddress("glBindFramebuffer");
+    glFramebufferTexture2D = (PFNGLFRAMEBUFFERTEXTURE2DPROC)imgl3wGetProcAddress("glFramebufferTexture2D");
+    glCheckFramebufferStatus = (PFNGLCHECKFRAMEBUFFERSTATUSPROC)imgl3wGetProcAddress("glCheckFramebufferStatus");
+    glDrawArrays = (PFNGLDRAWARRAYSPROC)imgl3wGetProcAddress("glDrawArrays");
+#endif
+
+    // Compile vertex shader
+    GLuint vertex_shader = glCreateShader(GL_VERTEX_SHADER);
+    glShaderSource(vertex_shader, 1, &g_VertexShaderSource, nullptr);
+    glCompileShader(vertex_shader);
+
+    // Check vertex shader compilation
+    GLint success = 0;
+    glGetShaderiv(vertex_shader, GL_COMPILE_STATUS, &success);
+    if (!success) {
+        char info_log[512];
+        glGetShaderInfoLog(vertex_shader, 512, nullptr, info_log);
+        IM_ASSERT_USER_ERROR(false, "ImPlot3D: Vertex shader compilation failed!");
+        IMGUI_DEBUG_PRINTF("ImPlot3D: Vertex shader error: %s\n", info_log);
+        return false;
+    }
+
+    // Compile fragment shader
+    GLuint fragment_shader = glCreateShader(GL_FRAGMENT_SHADER);
+    glShaderSource(fragment_shader, 1, &g_FragmentShaderSource, nullptr);
+    glCompileShader(fragment_shader);
+
+    // Check fragment shader compilation
+    glGetShaderiv(fragment_shader, GL_COMPILE_STATUS, &success);
+    if (!success) {
+        char info_log[512];
+        glGetShaderInfoLog(fragment_shader, 512, nullptr, info_log);
+        IM_ASSERT_USER_ERROR(false, "ImPlot3D: Fragment shader compilation failed!");
+        IMGUI_DEBUG_PRINTF("ImPlot3D: Fragment shader error: %s\n", info_log);
+        glDeleteShader(vertex_shader);
+        return false;
+    }
+
+    // Link shader program
+    g_Data.ShaderProgram = glCreateProgram();
+    glAttachShader(g_Data.ShaderProgram, vertex_shader);
+    glAttachShader(g_Data.ShaderProgram, fragment_shader);
+    glLinkProgram(g_Data.ShaderProgram);
+
+    // Check linking
+    glGetProgramiv(g_Data.ShaderProgram, GL_LINK_STATUS, &success);
+    if (!success) {
+        char info_log[512];
+        glGetProgramInfoLog(g_Data.ShaderProgram, 512, nullptr, info_log);
+        IM_ASSERT_USER_ERROR(false, "ImPlot3D: Shader program linking failed!");
+        IMGUI_DEBUG_PRINTF("ImPlot3D: Shader linking error: %s\n", info_log);
+        glDeleteShader(vertex_shader);
+        glDeleteShader(fragment_shader);
+        return false;
+    }
+
+    // Clean up shaders (no longer needed after linking)
+    glDeleteShader(vertex_shader);
+    glDeleteShader(fragment_shader);
+
+    // Get attribute locations
+    g_Data.AttribLocationPosition = glGetAttribLocation(g_Data.ShaderProgram, "Position");
+    g_Data.AttribLocationColor = glGetAttribLocation(g_Data.ShaderProgram, "Color");
+
+    // Create VAO and VBO
+    glGenVertexArrays(1, &g_Data.VAO);
+    glGenBuffers(1, &g_Data.VBO);
+
+    // Create FBO for offscreen rendering
+    glGenFramebuffers(1, &g_Data.FBO);
+
     return true;
 }
 
-void ImPlot3D_ImplOpenGL3_Shutdown() {
+IMPLOT3D_IMPL_API void ImPlot3D_ImplOpenGL3_Shutdown() {
+    // Delete OpenGL resources
+    if (g_Data.ShaderProgram)
+        glDeleteProgram(g_Data.ShaderProgram);
+    if (g_Data.VAO)
+        glDeleteVertexArrays(1, &g_Data.VAO);
+    if (g_Data.VBO)
+        glDeleteBuffers(1, &g_Data.VBO);
+    if (g_Data.FBO)
+        glDeleteFramebuffers(1, &g_Data.FBO);
+
     // Clean up any remaining textures
     for (int i = 0; i < g_CreatedTextures.Size; i++) {
         glDeleteTextures(1, &g_CreatedTextures[i]);
     }
     g_CreatedTextures.clear();
+
+    // Reset backend data
+    g_Data = ImPlot3D_ImplOpenGL3_Data();
 }
 
 ImTextureID ImPlot3D_ImplOpenGL3_CreateRGBATexture(const ImVec2& size) {
@@ -58,9 +220,9 @@ ImTextureID ImPlot3D_ImplOpenGL3_CreateRGBATexture(const ImVec2& size) {
             int idx = (y * width + x) * 4;
 
             // Create 2D rainbow: hue varies with x, saturation/brightness with y
-            float hue = (float)x / (float)width;        // 0.0 to 1.0 across width
-            float saturation = 1.0f;                     // Full saturation
-            float value = (float)y / (float)height;      // 0.0 to 1.0 across height
+            float hue = (float)x / (float)width;    // 0.0 to 1.0 across width
+            float saturation = 1.0f;                // Full saturation
+            float value = (float)y / (float)height; // 0.0 to 1.0 across height
 
             // HSV to RGB conversion
             float h = hue * 6.0f; // Hue in [0, 6)
@@ -70,24 +232,36 @@ ImTextureID ImPlot3D_ImplOpenGL3_CreateRGBATexture(const ImVec2& size) {
 
             float r, g, b;
             if (h < 1.0f) {
-                r = c; g = x_rgb; b = 0.0f;
+                r = c;
+                g = x_rgb;
+                b = 0.0f;
             } else if (h < 2.0f) {
-                r = x_rgb; g = c; b = 0.0f;
+                r = x_rgb;
+                g = c;
+                b = 0.0f;
             } else if (h < 3.0f) {
-                r = 0.0f; g = c; b = x_rgb;
+                r = 0.0f;
+                g = c;
+                b = x_rgb;
             } else if (h < 4.0f) {
-                r = 0.0f; g = x_rgb; b = c;
+                r = 0.0f;
+                g = x_rgb;
+                b = c;
             } else if (h < 5.0f) {
-                r = x_rgb; g = 0.0f; b = c;
+                r = x_rgb;
+                g = 0.0f;
+                b = c;
             } else {
-                r = c; g = 0.0f; b = x_rgb;
+                r = c;
+                g = 0.0f;
+                b = x_rgb;
             }
 
             // Convert to 0-255 range and store
             pixels[idx + 0] = (unsigned char)((r + m) * 255.0f); // R
             pixels[idx + 1] = (unsigned char)((g + m) * 255.0f); // G
             pixels[idx + 2] = (unsigned char)((b + m) * 255.0f); // B
-            pixels[idx + 3] = 255;                                // A (fully opaque)
+            pixels[idx + 3] = 255;                               // A (fully opaque)
         }
     }
 
@@ -141,8 +315,7 @@ IMPLOT3D_IMPL_API ImTextureID ImPlot3D_ImplOpenGL3_CreateDepthTexture(const ImVe
     // Create depth texture
     // GL_DEPTH_COMPONENT24: 24-bit depth precision (good balance of precision and memory)
     // Note: ImPlot3D targets OpenGL 3.0+ where depth textures are core
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT24, width, height, 0, GL_DEPTH_COMPONENT, GL_UNSIGNED_INT,
-                 nullptr);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT24, width, height, 0, GL_DEPTH_COMPONENT, GL_UNSIGNED_INT, nullptr);
 
     // Set texture parameters (recommended for depth textures)
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST); // No interpolation for depth
@@ -176,15 +349,93 @@ void ImPlot3D_ImplOpenGL3_DestroyTexture(ImTextureID tex_id) {
     }
 }
 
-void ImPlot3D_ImplOpenGL3_RenderPlots(ImPool<ImPlot3DPlot>* plots) {
+IMPLOT3D_IMPL_API void ImPlot3D_ImplOpenGL3_RenderPlots(ImPool<ImPlot3DPlot>* plots) {
+    if (!plots)
+        return;
+
+    // Vertex format: vec3 position, vec4 color
+    struct Vertex {
+        float x, y, z;
+        float r, g, b, a;
+    };
+
+    // Hardcoded rainbow triangle for testing
+    Vertex triangle[3] = {
+        {-0.5f, -0.5f, 0.0f, 1.0f, 0.0f, 0.0f, 1.0f}, // Red (bottom-left)
+        {0.5f, -0.5f, 0.0f, 0.0f, 1.0f, 0.0f, 1.0f},  // Green (bottom-right)
+        {0.0f, 0.5f, 0.0f, 0.0f, 0.0f, 1.0f, 1.0f},   // Blue (top)
+    };
+
+    // Iterate through all plots
     for (int i = 0; i < plots->GetBufSize(); i++) {
         ImPlot3DPlot* plot = plots->GetByIndex(i);
+
         // Create textures if they don't exist yet
         if (plot->ColorTextureID == ImTextureID_Invalid) {
             plot->ColorTextureID = ImPlot3D_ImplOpenGL3_CreateRGBATexture(plot->PlotRect.GetSize());
             plot->DepthTextureID = ImPlot3D_ImplOpenGL3_CreateDepthTexture(plot->PlotRect.GetSize());
         }
+
+        if (!plot || !plot->Initialized)
+            continue;
+
+        // Get texture IDs
+        GLuint color_texture = (GLuint)(intptr_t)plot->ColorTextureID;
+        GLuint depth_texture = (GLuint)(intptr_t)plot->DepthTextureID;
+
+        if (color_texture == 0)
+            continue; // Skip if no color texture
+
+        // Bind framebuffer
+        glBindFramebuffer(GL_FRAMEBUFFER, g_Data.FBO);
+
+        // Attach textures to framebuffer
+        glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, color_texture, 0);
+        if (depth_texture != 0) {
+            glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, depth_texture, 0);
+        }
+
+        // Check framebuffer status
+        GLenum status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
+        if (status != GL_FRAMEBUFFER_COMPLETE) {
+            IMGUI_DEBUG_PRINTF("ImPlot3D: Framebuffer not complete! Status: 0x%x\n", status);
+            glBindFramebuffer(GL_FRAMEBUFFER, 0);
+            continue;
+        }
+
+        // Set viewport to texture size
+        glViewport(0, 0, (int)plot->PlotRect.GetWidth(), (int)plot->PlotRect.GetHeight());
+
+        // Clear color and depth
+        glClearColor(0.1f, 0.1f, 0.1f, 1.0f);
+        glClear(GL_COLOR_BUFFER_BIT | (depth_texture != 0 ? GL_DEPTH_BUFFER_BIT : 0));
+
+        // Use shader program
+        glUseProgram(g_Data.ShaderProgram);
+
+        // Upload triangle data to VBO
+        glBindBuffer(GL_ARRAY_BUFFER, g_Data.VBO);
+        glBufferData(GL_ARRAY_BUFFER, sizeof(triangle), triangle, GL_STREAM_DRAW);
+
+        // Setup vertex attributes
+        glBindVertexArray(g_Data.VAO);
+        glEnableVertexAttribArray(g_Data.AttribLocationPosition);
+        glEnableVertexAttribArray(g_Data.AttribLocationColor);
+
+        glVertexAttribPointer(g_Data.AttribLocationPosition, 3, GL_FLOAT, GL_FALSE, sizeof(Vertex), (void*)offsetof(Vertex, x));
+        glVertexAttribPointer(g_Data.AttribLocationColor, 4, GL_FLOAT, GL_FALSE, sizeof(Vertex), (void*)offsetof(Vertex, r));
+
+        // Draw triangle
+        glDrawArrays(GL_TRIANGLES, 0, 3);
+
+        // Cleanup
+        glBindVertexArray(0);
+        glBindBuffer(GL_ARRAY_BUFFER, 0);
+        glUseProgram(0);
     }
+
+    // Unbind framebuffer (return to default)
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
 }
 
 #endif // #ifndef IMGUI_DISABLE

--- a/backends/implot3d_impl_opengl3.cpp
+++ b/backends/implot3d_impl_opengl3.cpp
@@ -3,7 +3,16 @@
 
 #include "implot3d.h"
 #ifndef IMGUI_DISABLE
+#include "imgui.h"
+#include "imgui_internal.h"
 #include "implot3d_impl_opengl3.h"
+#include <stdint.h>
+
+// OpenGL loader
+#include "imgui_impl_opengl3_loader.h"
+
+// Track created textures for cleanup
+static ImVector<GLuint> g_CreatedTextures;
 
 IMPLOT3D_IMPL_API bool ImPlot3D_ImplOpenGL3_Init() {
     // TODO
@@ -11,7 +20,113 @@ IMPLOT3D_IMPL_API bool ImPlot3D_ImplOpenGL3_Init() {
 }
 
 IMPLOT3D_IMPL_API void ImPlot3D_ImplOpenGL3_Shutdown() {
-    // TODO
+    // Clean up any remaining textures
+    for (int i = 0; i < g_CreatedTextures.Size; i++) {
+        glDeleteTextures(1, &g_CreatedTextures[i]);
+    }
+    g_CreatedTextures.clear();
+}
+
+IMPLOT3D_IMPL_API ImTextureID ImPlot3D_ImplOpenGL3_CreateTexture(const ImVec2& size) {
+    int width = (int)size.x;
+    int height = (int)size.y;
+
+    // Use ImGui's error handling for user-facing errors
+    IM_ASSERT_USER_ERROR(width > 0 && height > 0, "ImPlot3D_ImplOpenGL3_CreateTexture: size must be positive!");
+    if (width <= 0 || height <= 0)
+        return ImTextureID_Invalid;
+
+    // Create rainbow gradient pixel data (RGBA)
+    size_t pixel_count = (size_t)width * (size_t)height;
+    size_t data_size = pixel_count * 4; // 4 bytes per pixel (RGBA)
+
+    // Allocate using ImGui's allocation
+    unsigned char* pixels = (unsigned char*)IM_ALLOC(data_size);
+
+    // Generate rainbow gradient
+    // HSV to RGB conversion for smooth rainbow colors
+    for (int y = 0; y < height; y++) {
+        for (int x = 0; x < width; x++) {
+            int idx = (y * width + x) * 4;
+
+            // Create 2D rainbow: hue varies with x, saturation/brightness with y
+            float hue = (float)x / (float)width;        // 0.0 to 1.0 across width
+            float saturation = 1.0f;                     // Full saturation
+            float value = (float)y / (float)height;      // 0.0 to 1.0 across height
+
+            // HSV to RGB conversion
+            float h = hue * 6.0f; // Hue in [0, 6)
+            float c = value * saturation;
+            float x_rgb = c * (1.0f - ImFabs(ImFmod(h, 2.0f) - 1.0f));
+            float m = value - c;
+
+            float r, g, b;
+            if (h < 1.0f) {
+                r = c; g = x_rgb; b = 0.0f;
+            } else if (h < 2.0f) {
+                r = x_rgb; g = c; b = 0.0f;
+            } else if (h < 3.0f) {
+                r = 0.0f; g = c; b = x_rgb;
+            } else if (h < 4.0f) {
+                r = 0.0f; g = x_rgb; b = c;
+            } else if (h < 5.0f) {
+                r = x_rgb; g = 0.0f; b = c;
+            } else {
+                r = c; g = 0.0f; b = x_rgb;
+            }
+
+            // Convert to 0-255 range and store
+            pixels[idx + 0] = (unsigned char)((r + m) * 255.0f); // R
+            pixels[idx + 1] = (unsigned char)((g + m) * 255.0f); // G
+            pixels[idx + 2] = (unsigned char)((b + m) * 255.0f); // B
+            pixels[idx + 3] = 255;                                // A (fully opaque)
+        }
+    }
+
+    // Generate OpenGL texture
+    GLuint texture_id = 0;
+    GLint last_texture = 0;
+    glGetIntegerv(GL_TEXTURE_BINDING_2D, &last_texture);
+
+    glGenTextures(1, &texture_id);
+    glBindTexture(GL_TEXTURE_2D, texture_id);
+
+    // Set texture parameters
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+
+    // Upload pixel data to GPU
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, pixels);
+
+    // Free CPU memory
+    IM_FREE(pixels);
+
+    // Restore previous texture binding
+    glBindTexture(GL_TEXTURE_2D, last_texture);
+
+    // Track this texture for cleanup
+    g_CreatedTextures.push_back(texture_id);
+
+    // Return as ImTextureID (cast GLuint to ImTextureID)
+    return (ImTextureID)(intptr_t)texture_id;
+}
+
+IMPLOT3D_IMPL_API void ImPlot3D_ImplOpenGL3_DestroyTexture(ImTextureID tex_id) {
+    GLuint texture_id = (GLuint)(intptr_t)tex_id;
+
+    if (texture_id != 0) {
+        glDeleteTextures(1, &texture_id);
+
+        // Remove from tracking vector
+        for (int i = 0; i < g_CreatedTextures.Size; i++) {
+            if (g_CreatedTextures[i] == texture_id) {
+                g_CreatedTextures.erase(&g_CreatedTextures[i]);
+                break;
+            }
+        }
+    }
 }
 
 #endif // #ifndef IMGUI_DISABLE

--- a/backends/implot3d_impl_opengl3.cpp
+++ b/backends/implot3d_impl_opengl3.cpp
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2024-2026 Breno Cunha Queiroz
+
+#include "implot3d.h"
+#ifndef IMGUI_DISABLE
+#include "implot3d_impl_opengl3.h"
+
+IMPLOT3D_IMPL_API bool ImPlot3D_ImplOpenGL3_Init() {
+    // TODO
+    return true;
+}
+
+IMPLOT3D_IMPL_API void ImPlot3D_ImplOpenGL3_Shutdown() {
+    // TODO
+}
+
+#endif // #ifndef IMGUI_DISABLE

--- a/backends/implot3d_impl_opengl3.cpp
+++ b/backends/implot3d_impl_opengl3.cpp
@@ -567,9 +567,6 @@ IMPLOT3D_IMPL_API void ImPlot3D_ImplOpenGL3_RenderDrawData(ImDrawData3D* draw_da
         for (int cmd_i = 0; cmd_i < plot_data->CmdBuffer.Size; cmd_i++) {
             const ImDrawCmd3D& cmd = plot_data->CmdBuffer[cmd_i];
 
-            // Phase 3: Assert all commands are triangles (line support comes in Phase 6)
-            IM_ASSERT(cmd.Type == ImDrawCmd3DType_Triangles && "Phase 3: Only triangle commands supported");
-
             // Draw triangles for this command
             glDrawElements(GL_TRIANGLES, cmd.IdxCount, GL_UNSIGNED_INT, (void*)(cmd.IdxOffset * sizeof(ImDrawIdx3D)));
         }

--- a/backends/implot3d_impl_opengl3.h
+++ b/backends/implot3d_impl_opengl3.h
@@ -11,7 +11,4 @@ IMPLOT3D_IMPL_API void ImPlot3D_ImplOpenGL3_Shutdown();
 
 IMPLOT3D_IMPL_API void ImPlot3D_ImplOpenGL3_RenderPlots(ImPool<ImPlot3DPlot>* plots);
 
-IMPLOT3D_IMPL_API ImTextureID ImPlot3D_ImplOpenGL3_CreateTexture(const ImVec2& size);
-IMPLOT3D_IMPL_API void ImPlot3D_ImplOpenGL3_DestroyTexture(ImTextureID tex_id);
-
 #endif // #ifndef IMGUI_DISABLE

--- a/backends/implot3d_impl_opengl3.h
+++ b/backends/implot3d_impl_opengl3.h
@@ -3,10 +3,13 @@
 
 #pragma once
 #include "implot3d.h"
+#include "implot3d_internal.h"
 #ifndef IMGUI_DISABLE
 
 IMPLOT3D_IMPL_API bool ImPlot3D_ImplOpenGL3_Init();
 IMPLOT3D_IMPL_API void ImPlot3D_ImplOpenGL3_Shutdown();
+
+IMPLOT3D_IMPL_API void ImPlot3D_ImplOpenGL3_RenderPlots(ImPool<ImPlot3DPlot>* plots);
 
 IMPLOT3D_IMPL_API ImTextureID ImPlot3D_ImplOpenGL3_CreateTexture(const ImVec2& size);
 IMPLOT3D_IMPL_API void ImPlot3D_ImplOpenGL3_DestroyTexture(ImTextureID tex_id);

--- a/backends/implot3d_impl_opengl3.h
+++ b/backends/implot3d_impl_opengl3.h
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2024-2026 Breno Cunha Queiroz
+
+#pragma once
+#include "implot3d.h"
+#ifndef IMGUI_DISABLE
+
+IMPLOT3D_IMPL_API bool ImPlot3D_ImplOpenGL3_Init();
+IMPLOT3D_IMPL_API void ImPlot3D_ImplOpenGL3_Shutdown();
+
+#endif // #ifndef IMGUI_DISABLE

--- a/backends/implot3d_impl_opengl3.h
+++ b/backends/implot3d_impl_opengl3.h
@@ -8,4 +8,7 @@
 IMPLOT3D_IMPL_API bool ImPlot3D_ImplOpenGL3_Init();
 IMPLOT3D_IMPL_API void ImPlot3D_ImplOpenGL3_Shutdown();
 
+IMPLOT3D_IMPL_API ImTextureID ImPlot3D_ImplOpenGL3_CreateTexture(const ImVec2& size);
+IMPLOT3D_IMPL_API void ImPlot3D_ImplOpenGL3_DestroyTexture(ImTextureID tex_id);
+
 #endif // #ifndef IMGUI_DISABLE

--- a/backends/implot3d_impl_opengl3.h
+++ b/backends/implot3d_impl_opengl3.h
@@ -9,6 +9,6 @@
 IMPLOT3D_IMPL_API bool ImPlot3D_ImplOpenGL3_Init();
 IMPLOT3D_IMPL_API void ImPlot3D_ImplOpenGL3_Shutdown();
 
-IMPLOT3D_IMPL_API void ImPlot3D_ImplOpenGL3_RenderPlots(ImPool<ImPlot3DPlot>* plots);
+IMPLOT3D_IMPL_API void ImPlot3D_ImplOpenGL3_RenderDrawData(ImDrawData3D* draw_data);
 
 #endif // #ifndef IMGUI_DISABLE

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -65,9 +65,10 @@ set(IMPLOT3D_SOURCE
     ${IMPLOT3D_SOURCE_DIR}/implot3d_demo.cpp
     ${IMPLOT3D_SOURCE_DIR}/implot3d_items.cpp
     ${IMPLOT3D_SOURCE_DIR}/implot3d_meshes.cpp
+    ${IMPLOT3D_SOURCE_DIR}/backends/implot3d_impl_opengl3.cpp
 )
 add_library(implot3d STATIC ${IMPLOT3D_SOURCE})
-target_include_directories(implot3d PUBLIC ${IMPLOT3D_SOURCE_DIR})
+target_include_directories(implot3d PUBLIC ${IMPLOT3D_SOURCE_DIR};${IMPLOT3D_SOURCE_DIR}/backends/)
 target_link_libraries(implot3d PUBLIC imgui)
 
 # Add the executable

--- a/example/main.cpp
+++ b/example/main.cpp
@@ -79,14 +79,17 @@ int main() {
         ImPlot::ShowDemoWindow();
         ImPlot3D::ShowDemoWindow();
 
-        // Render
+        // Prepare draw data for rendering
         ImGui::Render();
+        ImPlot3D::Render();
+
+        // Render draw data
         int display_w, display_h;
         glfwGetFramebufferSize(window, &display_w, &display_h);
         glViewport(0, 0, display_w, display_h);
         glClearColor(0.1f, 0.1f, 0.1f, 1.0f);
         glClear(GL_COLOR_BUFFER_BIT);
-        ImPlot3D_ImplOpenGL3_RenderPlots(ImPlot3D::GetPlots());
+        ImPlot3D_ImplOpenGL3_RenderDrawData(ImPlot3D::GetDrawData());
         ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
 
         // Swap buffers

--- a/example/main.cpp
+++ b/example/main.cpp
@@ -8,6 +8,7 @@
 #include "imgui_impl_opengl3.h"
 #include "implot.h"
 #include "implot3d.h"
+#include "implot3d_internal.h"
 #include "implot3d_impl_opengl3.h"
 #include <GLFW/glfw3.h>
 #include <iostream>
@@ -85,6 +86,7 @@ int main() {
         glViewport(0, 0, display_w, display_h);
         glClearColor(0.1f, 0.1f, 0.1f, 1.0f);
         glClear(GL_COLOR_BUFFER_BIT);
+        ImPlot3D_ImplOpenGL3_RenderPlots(ImPlot3D::GetPlots());
         ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
 
         // Swap buffers

--- a/example/main.cpp
+++ b/example/main.cpp
@@ -8,6 +8,7 @@
 #include "imgui_impl_opengl3.h"
 #include "implot.h"
 #include "implot3d.h"
+#include "implot3d_impl_opengl3.h"
 #include <GLFW/glfw3.h>
 #include <iostream>
 
@@ -61,6 +62,7 @@ int main() {
     // Setup backend
     ImGui_ImplGlfw_InitForOpenGL(window, true);
     ImGui_ImplOpenGL3_Init(glsl_version);
+    ImPlot3D_ImplOpenGL3_Init();
 
     // Main loop
     while (!glfwWindowShouldClose(window)) {
@@ -90,6 +92,7 @@ int main() {
     }
 
     // Cleanup
+    ImPlot3D_ImplOpenGL3_Shutdown();
     ImGui_ImplOpenGL3_Shutdown();
     ImGui_ImplGlfw_Shutdown();
     ImPlot3D::DestroyContext();

--- a/implot3d.cpp
+++ b/implot3d.cpp
@@ -129,7 +129,6 @@ implot3d files. You can read releases logs https://github.com/brenocq/implot3d/r
 
 #include "implot3d.h"
 #include "implot3d_internal.h"
-#include "implot3d_impl_opengl3.h"
 
 #ifndef IMGUI_DISABLE
 
@@ -1646,9 +1645,6 @@ void EndPlot() {
     } else {
         // Move triangles from 3D draw list to ImGui draw list
         plot.DrawList.SortedMoveToImGuiDrawList();
-        // XXX Create color texture
-        plot.ColorTextureID = ImPlot3D_ImplOpenGL3_CreateTexture(plot.PlotRect.GetSize());
-        // TODO make sure texture is deleted when plot is deleted
     }
 
 
@@ -1984,6 +1980,8 @@ void SetupLegend(ImPlot3DLocation location, ImPlot3DLegendFlags flags) {
 //-----------------------------------------------------------------------------
 // [SECTION] Plot Utils
 //-----------------------------------------------------------------------------
+
+ImPool<ImPlot3DPlot>* GetPlots() { return &GImPlot3D->Plots; }
 
 ImPlot3DPlot* GetCurrentPlot() { return GImPlot3D->CurrentPlot; }
 

--- a/implot3d.cpp
+++ b/implot3d.cpp
@@ -253,6 +253,19 @@ void Render() {
         plot_data->PlotRectMin = plot->PlotRect.Min;
         plot_data->PlotRectMax = plot->PlotRect.Max;
 
+        // Set clipping parameters
+        // Note: NDC cube is [-0.5*NDCScale, 0.5*NDCScale] per axis
+        plot_data->ShouldClip = !(plot->Flags & ImPlot3DFlags_NoClip);
+        if (plot_data->ShouldClip) {
+            // Clip to full NDC cube using per-axis NDCScale
+            plot_data->ClipMin = ImPlot3DPoint(-0.5 * plot->Axes[ImAxis3D_X].NDCScale,
+                                               -0.5 * plot->Axes[ImAxis3D_Y].NDCScale,
+                                               -0.5 * plot->Axes[ImAxis3D_Z].NDCScale);
+            plot_data->ClipMax = ImPlot3DPoint(0.5 * plot->Axes[ImAxis3D_X].NDCScale,
+                                               0.5 * plot->Axes[ImAxis3D_Y].NDCScale,
+                                               0.5 * plot->Axes[ImAxis3D_Z].NDCScale);
+        }
+
         plot->DrawList.ResetBuffers(); // Clear plot's draw list for next frame
     }
 }

--- a/implot3d.cpp
+++ b/implot3d.cpp
@@ -1636,16 +1636,16 @@ void EndPlot() {
     IM_ASSERT_USER_ERROR(gp.CurrentPlot != nullptr, "Mismatched BeginPlot()/EndPlot()!");
     ImPlot3DPlot& plot = *gp.CurrentPlot;
 
-    // if (plot.ColorTextureID != ImTextureID_Invalid) {
-    //     ImDrawList& draw_list = *ImGui::GetWindowDrawList();
-    //     ImVec2 uv0 = ImVec2(0, 0);
-    //     ImVec2 uv1 = ImVec2(1, 1);
-    //     ImU32 col = IM_COL32(255, 255, 255, 255);
-    //     draw_list.AddImage(plot.ColorTextureID, plot.PlotRect.Min, plot.PlotRect.Max, uv0, uv1, col);
-    // } else {
-    //  Move triangles from 3D draw list to ImGui draw list
-    plot.DrawList.SortedMoveToImGuiDrawList();
-    //}
+    if (gp.UseImPlot3DBackend && plot.ColorTextureID != ImTextureID_Invalid) {
+        ImDrawList& draw_list = *ImGui::GetWindowDrawList();
+        ImVec2 uv0 = ImVec2(0, 0);
+        ImVec2 uv1 = ImVec2(1, 1);
+        ImU32 col = IM_COL32(255, 255, 255, 255);
+        draw_list.AddImage(plot.ColorTextureID, plot.PlotRect.Min, plot.PlotRect.Max, uv0, uv1, col);
+    } else {
+        //  Move triangles from 3D draw list to ImGui draw list
+        plot.DrawList.SortedMoveToImGuiDrawList();
+    }
 
     // Handle data fitting
     if (plot.FitThisFrame) {
@@ -3191,6 +3191,7 @@ bool ColormapSlider(const char* label, float* t, ImVec4* out, const char* format
 
 void InitializeContext(ImPlot3DContext* ctx) {
     ResetContext(ctx);
+    ctx->UseImPlot3DBackend = false; // Disabled by default
 
     const ImU32 Deep[] = {4289753676, 4283598045, 4285048917, 4283584196, 4289950337, 4284512403, 4291005402, 4287401100, 4285839820, 4291671396};
     const ImU32 Dark[] = {4280031972, 4290281015, 4283084621, 4288892568, 4278222847, 4281597951, 4280833702, 4290740727, 4288256409};
@@ -3964,6 +3965,7 @@ void ImPlot3D::ShowMetricsWindow(bool* p_popen) {
         ImGui::SameLine();
         if (ImGui::Button("Bust Item Cache"))
             BustItemCache();
+        ImGui::Checkbox("Use ImPlot3D Backend", &gp.UseImPlot3DBackend);
         ImGui::Checkbox("Show Frame Rects", &show_frame_rects);
         ImGui::Checkbox("Show Canvas Rects", &show_canvas_rects);
         ImGui::Checkbox("Show Plot Rects", &show_plot_rects);

--- a/implot3d.cpp
+++ b/implot3d.cpp
@@ -171,6 +171,27 @@ ImPlot3DContext* GetCurrentContext() { return GImPlot3D; }
 
 void SetCurrentContext(ImPlot3DContext* ctx) { GImPlot3D = ctx; }
 
+void Render() {
+    ImPlot3DContext& gp = *GImPlot3D;
+    IM_ASSERT_USER_ERROR(gp.CurrentPlot == nullptr, "Render() called between BeginPlot() and EndPlot()!");
+
+    // Clear previous draw data
+    gp.DrawData.Clear();
+
+    // Collect all active plots
+    for (int i = 0; i < gp.Plots.GetBufSize(); i++) {
+        ImPlot3DPlot* plot = gp.Plots.GetByIndex(i);
+        if (plot && plot->Initialized) {
+            gp.DrawData.Plots.push_back(plot);
+        }
+    }
+}
+
+ImDrawData3D* GetDrawData() {
+    ImPlot3DContext& gp = *GImPlot3D;
+    return &gp.DrawData;
+}
+
 //-----------------------------------------------------------------------------
 // [SECTION] Text Utils
 //-----------------------------------------------------------------------------
@@ -3960,12 +3981,15 @@ void ImPlot3D::ShowMetricsWindow(bool* p_popen) {
     ImGui::Text("Mouse Position: [%.0f,%.0f]", io.MousePos.x, io.MousePos.y);
     ImGui::Separator();
     if (ImGui::TreeNode("Tools")) {
+        ImGui::SeparatorText("Cache");
         if (ImGui::Button("Bust Plot Cache"))
             BustPlotCache();
         ImGui::SameLine();
         if (ImGui::Button("Bust Item Cache"))
             BustItemCache();
+        ImGui::SeparatorText("Rendering");
         ImGui::Checkbox("Use ImPlot3D Backend", &gp.UseImPlot3DBackend);
+        ImGui::SeparatorText("Visualize");
         ImGui::Checkbox("Show Frame Rects", &show_frame_rects);
         ImGui::Checkbox("Show Canvas Rects", &show_canvas_rects);
         ImGui::Checkbox("Show Plot Rects", &show_plot_rects);

--- a/implot3d.cpp
+++ b/implot3d.cpp
@@ -3727,8 +3727,8 @@ double ImPlot3DQuat::Dot(const ImPlot3DQuat& rhs) const { return x * rhs.x + y *
 // [SECTION] ImDrawList3D
 //-----------------------------------------------------------------------------
 
-void ImDrawList3D::PrimReserve(int idx_count, int vtx_count) {
-    IM_ASSERT_PARANOID(idx_count >= 0 && vtx_count >= 0 && idx_count % 3 == 0);
+void ImDrawList3D::PrimReserve(int idx_count, int vtx_count, int z_count) {
+    IM_ASSERT_PARANOID(idx_count >= 0 && vtx_count >= 0 && z_count >= 0);
 
     int vtx_buffer_old_size = VtxBuffer.Size;
     VtxBuffer.resize(vtx_buffer_old_size + vtx_count);
@@ -3739,16 +3739,16 @@ void ImDrawList3D::PrimReserve(int idx_count, int vtx_count) {
     _IdxWritePtr = IdxBuffer.Data + idx_buffer_old_size;
 
     int z_buffer_old_size = ZBuffer.Size;
-    ZBuffer.resize(z_buffer_old_size + idx_count / 3);
+    ZBuffer.resize(z_buffer_old_size + z_count);
     _ZWritePtr = ZBuffer.Data + z_buffer_old_size;
 }
 
-void ImDrawList3D::PrimUnreserve(int idx_count, int vtx_count) {
-    IM_ASSERT_PARANOID(idx_count >= 0 && vtx_count >= 0 && idx_count % 3 == 0);
+void ImDrawList3D::PrimUnreserve(int idx_count, int vtx_count, int z_count) {
+    IM_ASSERT_PARANOID(idx_count >= 0 && vtx_count >= 0 && z_count >= 0);
 
     VtxBuffer.shrink(VtxBuffer.Size - vtx_count);
     IdxBuffer.shrink(IdxBuffer.Size - idx_count);
-    ZBuffer.shrink(ZBuffer.Size - idx_count / 3);
+    ZBuffer.shrink(ZBuffer.Size - z_count);
 }
 
 void ImDrawList3D::SetTexture(ImTextureRef tex_ref) {

--- a/implot3d.cpp
+++ b/implot3d.cpp
@@ -251,6 +251,10 @@ void Render() {
         // Copy commands
         plot_data->CmdBuffer = plot->DrawList.CmdBuffer;
 
+        // Copy line and marker primitives
+        plot_data->LineBuffer = plot->DrawList.LineBuffer;
+        plot_data->MarkerBuffer = plot->DrawList.MarkerBuffer;
+
         // Copy plot state needed for rendering
         plot_data->Rotation = plot->Rotation;
         plot_data->PlotRectMin = plot->PlotRect.Min;
@@ -258,7 +262,7 @@ void Render() {
 
         // Set clipping parameters
         // Note: NDC cube is [-0.5*NDCScale, 0.5*NDCScale] per axis
-        plot_data->ShouldClip = !(plot->Flags & ImPlot3DFlags_NoClip);
+        plot_data->ShouldClip = !ImHasFlag(plot->Flags, ImPlot3DFlags_NoClip);
         if (plot_data->ShouldClip) {
             // Clip to full NDC cube using per-axis NDCScale
             plot_data->ClipMin =
@@ -3762,11 +3766,9 @@ void ImDrawList3D::AddTriangleCmd(int idx_count) {
     // Check if we can extend the last command
     if (CmdBuffer.Size > 0) {
         ImDrawCmd3D* last_cmd = &CmdBuffer[CmdBuffer.Size - 1];
-        if (last_cmd->Type == ImDrawCmd3DType_Triangles) {
-            // Extend existing triangle command
-            last_cmd->IdxCount += idx_count;
-            return;
-        }
+        // Extend existing triangle command
+        last_cmd->IdxCount += idx_count;
+        return;
     }
 
     // Create new triangle command
@@ -3778,10 +3780,32 @@ void ImDrawList3D::AddTriangleCmd(int idx_count) {
     }
 
     PrimReserveCmd(1);
-    _CmdWritePtr->Type = ImDrawCmd3DType_Triangles;
     _CmdWritePtr->IdxOffset = next_offset;
     _CmdWritePtr->IdxCount = idx_count;
-    _CmdWritePtr->LineWeight = 0.0f;
+}
+
+void ImDrawList3D::AddLine(const ImPlot3DPoint& p0, const ImPlot3DPoint& p1, double z, ImU32 col0, ImU32 col1, float weight) {
+    ImDrawLinePrim prim;
+    prim.p0 = p0;
+    prim.p1 = p1;
+    prim.z = z;
+    prim.col0 = col0;
+    prim.col1 = col1;
+    prim.weight = weight;
+    LineBuffer.push_back(prim);
+}
+
+void ImDrawList3D::AddMarker(const ImPlot3DPoint& center, double z, ImU32 fill_col, ImU32 line_col, float size, float line_weight,
+                             ImPlot3DMarker type) {
+    ImDrawMarkerPrim prim;
+    prim.center = center;
+    prim.z = z;
+    prim.fill_col = fill_col;
+    prim.line_col = line_col;
+    prim.size = size;
+    prim.line_weight = line_weight;
+    prim.type = type;
+    MarkerBuffer.push_back(prim);
 }
 
 void ImDrawList3D::SetTexture(ImTextureRef tex_ref) {

--- a/implot3d.h
+++ b/implot3d.h
@@ -45,6 +45,10 @@
 #define IMPLOT3D_API
 #endif
 
+#ifndef IMPLOT3D_IMPL_API
+#define IMPLOT3D_IMPL_API IMPLOT3D_API
+#endif
+
 #define IMPLOT3D_VERSION "0.4 WIP"            // ImPlot3D version
 #define IMPLOT3D_VERSION_NUM 401              // Integer encoded version
 #define IMPLOT3D_AUTO -1                      // Deduce variable automatically

--- a/implot3d.h
+++ b/implot3d.h
@@ -1129,6 +1129,9 @@ struct ImDrawData3DPlot {
     bool ShouldResize;                // Set by Render() if texture needs resizing
     bool ShouldRender;                // Set by Render() if plot should be rendered
     bool ShouldDelete;                // Set by Render() if plot no longer exists
+    bool ShouldClip;                  // Set by Render() if clipping is enabled
+    ImPlot3DPoint ClipMin;            // Min clip bounds in NDC space
+    ImPlot3DPoint ClipMax;            // Max clip bounds in NDC space
 
     ImDrawData3DPlot() {
         PlotID = 0;
@@ -1141,6 +1144,8 @@ struct ImDrawData3DPlot {
         ShouldResize = false;
         ShouldRender = false;
         ShouldDelete = false;
+        ShouldClip = true;
+        ClipMin = ClipMax = ImPlot3DPoint(0.0, 0.0, 0.0);
     }
 
     float GetPlotWidth() const { return PlotRectMax.x - PlotRectMin.x; }

--- a/implot3d.h
+++ b/implot3d.h
@@ -68,6 +68,8 @@ struct ImPlot3DPlane;
 struct ImPlot3DBox;
 struct ImPlot3DRange;
 struct ImPlot3DQuat;
+struct ImDrawData3D;
+struct ImPlot3DPlot;
 
 // Enums
 typedef int ImPlot3DCond;     // -> ImPlot3DCond_              // Enum: Condition for flags
@@ -466,6 +468,11 @@ IMPLOT3D_API void DestroyContext(ImPlot3DContext* ctx = nullptr);
 IMPLOT3D_API ImPlot3DContext* GetCurrentContext();
 // Sets the current ImPlot3D context
 IMPLOT3D_API void SetCurrentContext(ImPlot3DContext* ctx);
+
+// Prepares draw data for rendering. Call this after all ImPlot3D plots have been drawn
+IMPLOT3D_API void Render();
+// Returns the draw data for rendering. Valid after Render() and before next NewFrame()
+IMPLOT3D_API ImDrawData3D* GetDrawData();
 
 //-----------------------------------------------------------------------------
 // [SECTION] Begin/End Plot
@@ -1012,8 +1019,7 @@ struct ImPlot3DStyle {
     // Constructor
     IMPLOT3D_API ImPlot3DStyle();
     ImPlot3DStyle(const ImPlot3DStyle& other) = default;
-    ImPlot3DStyle& operator=(const ImPlot3DStyle& other) =
-  default;
+    ImPlot3DStyle& operator=(const ImPlot3DStyle& other) = default;
 };
 
 //-----------------------------------------------------------------------------
@@ -1043,6 +1049,18 @@ extern unsigned int duck_idx[DUCK_IDX_COUNT];  // Duck indices
 } // namespace ImPlot3D
 
 //-----------------------------------------------------------------------------
+// [SECTION] ImDrawData3D
+//-----------------------------------------------------------------------------
+
+// Draw data for rendering all plots. Valid after Render() and before next NewFrame()
+struct ImDrawData3D {
+    ImVector<ImPlot3DPlot*> Plots; // All plots to be rendered
+
+    ImDrawData3D() { Clear(); }
+    void Clear() { Plots.clear(); }
+};
+
+//-----------------------------------------------------------------------------
 // [SECTION] Obsolete API
 //-----------------------------------------------------------------------------
 
@@ -1070,11 +1088,16 @@ extern unsigned int duck_idx[DUCK_IDX_COUNT];  // Duck indices
 namespace ImPlot3D {
 
 // OBSOLETED in v0.4 (from February 2026)
-// IMPLOT_API void SetNextLineStyle(const ImVec4& col = IMPLOT_AUTO_COL, float weight = IMPLOT_AUTO); // OBSOLETED IN v0.4 // Set ImPlotSpec.LineColor/LineWeight or construct ImPlotSpec with { ImPlotSpec_LineColor, color, ImPlotSpec_LineWeight, weight }.
+// IMPLOT_API void SetNextLineStyle(const ImVec4& col = IMPLOT_AUTO_COL, float weight = IMPLOT_AUTO); // OBSOLETED IN v0.4 // Set
+// ImPlotSpec.LineColor/LineWeight or construct ImPlotSpec with { ImPlotSpec_LineColor, color, ImPlotSpec_LineWeight, weight }.
 
-// IMPLOT_API void SetNextFillStyle(const ImVec4& col = IMPLOT_AUTO_COL, float alpha_mod = IMPLOT_AUTO);// OBSOLETED IN v0.4 // Set ImPlotSpec.FillColor/FillAlpha or construct ImPlotSpec with { ImPlotSpec_FillColor, color, ImPlotSpec_FillAlpha, alpha }.
+// IMPLOT_API void SetNextFillStyle(const ImVec4& col = IMPLOT_AUTO_COL, float alpha_mod = IMPLOT_AUTO);// OBSOLETED IN v0.4 // Set
+// ImPlotSpec.FillColor/FillAlpha or construct ImPlotSpec with { ImPlotSpec_FillColor, color, ImPlotSpec_FillAlpha, alpha }.
 
-// IMPLOT_API void SetNextMarkerStyle(ImPlotMarker marker = IMPLOT_AUTO, float size = IMPLOT_AUTO, const ImVec4& fill = IMPLOT_AUTO_COL, float weight = IMPLOT_AUTO, const ImVec4& outline = IMPLOT_AUTO_COL); // OBSOLETED IN v0.4 // Set ImPlotSpec.Marker/MarkerSize/MarkerFillColor/LineWeight/MarkerLineColor or construct ImPlotSpec with { ImPlotSpec_Marker, marker, ImPlotSpec_MarkerSize, size, ImPlotSpec_MarkerFillColor, fill_color, ImPlotSpec_LineWeight, weight, ImPlotSpec_MarkerLineColor, outline }.
+// IMPLOT_API void SetNextMarkerStyle(ImPlotMarker marker = IMPLOT_AUTO, float size = IMPLOT_AUTO, const ImVec4& fill = IMPLOT_AUTO_COL, float weight
+// = IMPLOT_AUTO, const ImVec4& outline = IMPLOT_AUTO_COL); // OBSOLETED IN v0.4 // Set
+// ImPlotSpec.Marker/MarkerSize/MarkerFillColor/LineWeight/MarkerLineColor or construct ImPlotSpec with { ImPlotSpec_Marker, marker,
+// ImPlotSpec_MarkerSize, size, ImPlotSpec_MarkerFillColor, fill_color, ImPlotSpec_LineWeight, weight, ImPlotSpec_MarkerLineColor, outline }.
 
 // OBSOLETED in v0.3 -> PLANNED REMOVAL in v1.0
 IMPLOT3D_DEPRECATED(IMPLOT3D_API ImVec2 GetPlotPos());  // Renamed to GetPlotRectPos()

--- a/implot3d.h
+++ b/implot3d.h
@@ -1121,8 +1121,10 @@ struct ImDrawData3DPlot {
     ImPlot3DQuat Rotation;            // Rotation quaternion for this plot
     ImVec2 PlotRectMin;               // Plot rectangle min (for viewport)
     ImVec2 PlotRectMax;               // Plot rectangle max (for viewport)
-    ImTextureID ColorTextureID;       // RGBA texture for rendering
+    ImTextureID ColorTextureID;       // Final RGBA texture for rendering
     ImTextureID DepthTextureID;       // Depth texture for depth testing
+    ImTextureID AccumTextureID;       // WBOIT accumulation texture
+    ImTextureID RevealTextureID;      // WBOIT reveal texture
     ImVec2 TextureSize;               // Current texture size
     bool ShouldResize;                // Set by Render() if texture needs resizing
     bool ShouldRender;                // Set by Render() if plot should be rendered
@@ -1133,6 +1135,8 @@ struct ImDrawData3DPlot {
         Rotation = ImPlot3DQuat(0.0, 0.0, 0.0, 1.0);
         ColorTextureID = ImTextureID_Invalid;
         DepthTextureID = ImTextureID_Invalid;
+        AccumTextureID = ImTextureID_Invalid;
+        RevealTextureID = ImTextureID_Invalid;
         TextureSize = ImVec2(0.0f, 0.0f);
         ShouldResize = false;
         ShouldRender = false;

--- a/implot3d.h
+++ b/implot3d.h
@@ -1086,8 +1086,8 @@ struct ImDrawList3D {
         ResetBuffers();
     }
 
-    void PrimReserve(int idx_count, int vtx_count);
-    void PrimUnreserve(int idx_count, int vtx_count);
+    void PrimReserve(int idx_count, int vtx_count, int z_count);
+    void PrimUnreserve(int idx_count, int vtx_count, int z_count);
 
     void SetTexture(ImTextureRef tex_ref);
     void ResetTexture();

--- a/implot3d.h
+++ b/implot3d.h
@@ -1061,18 +1061,34 @@ struct ImDrawVert3D {
     ImU32 col;
 };
 
-// Command type for 3D rendering
-enum ImDrawCmd3DType { ImDrawCmd3DType_Triangles, ImDrawCmd3DType_Lines };
-
-// Draw command for 3D primitives. Tracks batches of lines or triangles.
+// Draw command for 3D triangles. Tracks batches of triangles with optional texturing.
 struct ImDrawCmd3D {
-    ImDrawCmd3DType Type;   // Primitive type (lines or triangles)
     unsigned int IdxOffset; // Start index in IdxBuffer
     unsigned int IdxCount;  // Number of indices in this command
-    float LineWeight;       // Line weight in pixels (only used for lines)
 };
 
-// List of all triangles to render for a given plot
+// Line primitive storing two NDC endpoints. Rendered as a screen-space quad by the backend.
+struct ImDrawLinePrim {
+    ImPlot3DPoint p0; // NDC start position
+    ImPlot3DPoint p1; // NDC end position
+    double z;         // Depth value for Z sorting
+    ImU32 col0;       // Color at p0
+    ImU32 col1;       // Color at p1
+    float weight;     // Line width in pixels
+};
+
+// Marker primitive storing a single NDC center point. Rendered as a screen-aligned sprite by the backend.
+struct ImDrawMarkerPrim {
+    ImPlot3DPoint center; // NDC center position
+    double z;             // Depth value for Z sorting
+    ImU32 fill_col;       // Fill color
+    ImU32 line_col;       // Outline color
+    float size;           // Marker size in pixels
+    float line_weight;    // Outline weight in pixels
+    ImPlot3DMarker type;  // Marker shape
+};
+
+// List of all primitives to render for a given plot
 struct ImDrawList3D {
     // [Internal] Define which texture should be used when rendering triangles.
     struct ImTextureBufferItem {
@@ -1080,16 +1096,21 @@ struct ImDrawList3D {
         unsigned int VtxIdx;
     };
 
+    // Triangle buffers
     ImVector<ImDrawIdx3D> IdxBuffer;  // Index buffer (32-bit indices)
     ImVector<ImDrawVert3D> VtxBuffer; // Vertex buffer (stores 3D NDC positions)
-    ImVector<double> ZBuffer;         // Z buffer. Depth value for each primitive
-    ImVector<ImDrawCmd3D> CmdBuffer;  // Command buffer (tracks primitive types and ranges)
-    unsigned int _VtxCurrentIdx;      // [Internal] current vertex index
-    ImDrawVert3D* _VtxWritePtr; // [Internal] point within VtxBuffer.Data after each add command (to avoid using the ImVector<> operators too much)
-    ImDrawIdx3D* _IdxWritePtr;  // [Internal] point within IdxBuffer.Data after each add command (to avoid using the ImVector<> operators too much)
-    double* _ZWritePtr;         // [Internal] point within ZBuffer.Data after each add command (to avoid using the ImVector<> operators too much)
-    ImDrawCmd3D* _CmdWritePtr;  // [Internal] point within CmdBuffer.Data after each add command (to avoid using the ImVector<> operators too much)
-    ImDrawListFlags _Flags;     // [Internal] draw list flags
+    ImVector<double> ZBuffer;         // Z buffer. Depth value for each triangle
+    ImVector<ImDrawCmd3D> CmdBuffer;  // Command buffer (tracks triangle batch ranges)
+    // Line and marker buffers (not tessellated; sent to backend for GPU rendering)
+    ImVector<ImDrawLinePrim> LineBuffer;     // Line segment primitives
+    ImVector<ImDrawMarkerPrim> MarkerBuffer; // Marker sprite primitives
+
+    unsigned int _VtxCurrentIdx; // [Internal] current vertex index
+    ImDrawVert3D* _VtxWritePtr;  // [Internal] point within VtxBuffer.Data after each add command (to avoid using the ImVector<> operators too much)
+    ImDrawIdx3D* _IdxWritePtr;   // [Internal] point within IdxBuffer.Data after each add command (to avoid using the ImVector<> operators too much)
+    double* _ZWritePtr;          // [Internal] point within ZBuffer.Data after each add command (to avoid using the ImVector<> operators too much)
+    ImDrawCmd3D* _CmdWritePtr;   // [Internal] point within CmdBuffer.Data after each add command (to avoid using the ImVector<> operators too much)
+    ImDrawListFlags _Flags;      // [Internal] draw list flags
     ImVector<ImTextureBufferItem> _TextureBuffer; // [Internal] buffer for SetTexture/ResetTexture
     ImDrawListSharedData* _SharedData;            // [Internal] shared draw list data
 
@@ -1104,6 +1125,8 @@ struct ImDrawList3D {
     void PrimReserveCmd(int cmd_count);
 
     void AddTriangleCmd(int idx_count);
+    void AddLine(const ImPlot3DPoint& p0, const ImPlot3DPoint& p1, double z, ImU32 col0, ImU32 col1, float weight);
+    void AddMarker(const ImPlot3DPoint& center, double z, ImU32 fill_col, ImU32 line_col, float size, float line_weight, ImPlot3DMarker type);
 
     void SetTexture(ImTextureRef tex_ref);
     void ResetTexture();
@@ -1115,6 +1138,8 @@ struct ImDrawList3D {
         VtxBuffer.clear();
         ZBuffer.clear();
         CmdBuffer.clear();
+        LineBuffer.clear();
+        MarkerBuffer.clear();
         _VtxCurrentIdx = 0;
         _VtxWritePtr = VtxBuffer.Data;
         _IdxWritePtr = IdxBuffer.Data;
@@ -1133,24 +1158,26 @@ struct ImDrawList3D {
 
 // Render data for a single plot. Contains a copy of the plot's draw list and texture state.
 struct ImDrawData3DPlot {
-    ImGuiID PlotID;                   // ID of the plot this render data belongs to
-    ImVector<ImDrawIdx3D> IdxBuffer;  // Copy of index buffer from plot
-    ImVector<ImDrawVert3D> VtxBuffer; // Copy of vertex buffer from plot
-    ImVector<ImDrawCmd3D> CmdBuffer;  // Copy of command buffer from plot
-    ImPlot3DQuat Rotation;            // Rotation quaternion for this plot
-    ImVec2 PlotRectMin;               // Plot rectangle min (for viewport)
-    ImVec2 PlotRectMax;               // Plot rectangle max (for viewport)
-    ImTextureID ColorTextureID;       // Final RGBA texture for rendering
-    ImTextureID DepthTextureID;       // Depth texture for depth testing
-    ImTextureID AccumTextureID;       // WBOIT accumulation texture
-    ImTextureID RevealTextureID;      // WBOIT reveal texture
-    ImVec2 TextureSize;               // Current texture size
-    bool ShouldResize;                // Set by Render() if texture needs resizing
-    bool ShouldRender;                // Set by Render() if plot should be rendered
-    bool ShouldDelete;                // Set by Render() if plot no longer exists
-    bool ShouldClip;                  // Set by Render() if clipping is enabled
-    ImPlot3DPoint ClipMin;            // Min clip bounds in NDC space
-    ImPlot3DPoint ClipMax;            // Max clip bounds in NDC space
+    ImGuiID PlotID;                          // ID of the plot this render data belongs to
+    ImVector<ImDrawIdx3D> IdxBuffer;         // Triangle index buffer
+    ImVector<ImDrawVert3D> VtxBuffer;        // Triangle vertex buffer
+    ImVector<ImDrawCmd3D> CmdBuffer;         // Triangle command buffer
+    ImVector<ImDrawLinePrim> LineBuffer;     // Line segment primitives
+    ImVector<ImDrawMarkerPrim> MarkerBuffer; // Marker sprite primitives
+    ImPlot3DQuat Rotation;                   // Rotation quaternion for this plot
+    ImVec2 PlotRectMin;                      // Plot rectangle min (for viewport)
+    ImVec2 PlotRectMax;                      // Plot rectangle max (for viewport)
+    ImTextureID ColorTextureID;              // Final RGBA texture for rendering
+    ImTextureID DepthTextureID;              // Depth texture for depth testing
+    ImTextureID AccumTextureID;              // WBOIT accumulation texture
+    ImTextureID RevealTextureID;             // WBOIT reveal texture
+    ImVec2 TextureSize;                      // Current texture size
+    bool ShouldResize;                       // Set by Render() if texture needs resizing
+    bool ShouldRender;                       // Set by Render() if plot should be rendered
+    bool ShouldDelete;                       // Set by Render() if plot no longer exists
+    bool ShouldClip;                         // Set by Render() if clipping is enabled
+    ImPlot3DPoint ClipMin;                   // Min clip bounds in NDC space
+    ImPlot3DPoint ClipMax;                   // Max clip bounds in NDC space
 
     ImDrawData3DPlot() {
         PlotID = 0;
@@ -1173,6 +1200,8 @@ struct ImDrawData3DPlot {
     void ResetBuffers() {
         IdxBuffer.clear();
         VtxBuffer.clear();
+        LineBuffer.clear();
+        MarkerBuffer.clear();
     }
 };
 

--- a/implot3d_demo.cpp
+++ b/implot3d_demo.cpp
@@ -555,6 +555,67 @@ void DemoImagePlots() {
     }
 }
 
+void DemoDepthBuffer() {
+    ImGui::BulletText("Two overlapping transparent surfaces to test depth buffer rendering.");
+    ImGui::BulletText("The surfaces should properly occlude each other based on depth.");
+
+    static float alpha = 0.8f;
+    ImGui::SliderFloat("Alpha", &alpha, 0.0f, 1.0f);
+
+    // Generate two surfaces
+    const int size = 10;
+    static double xs1[size * size], ys1[size * size], zs1[size * size];
+    static double xs2[size * size], ys2[size * size], zs2[size * size];
+    static bool initialized = false;
+
+    if (!initialized) {
+        // Define the range for X and Y
+        const double min_val = -1.0;
+        const double max_val = 1.0;
+        const double step = (max_val - min_val) / (size - 1);
+
+        // Surface 1: A tilted plane
+        for (int i = 0; i < size; i++) {
+            for (int j = 0; j < size; j++) {
+                int idx = i * size + j;
+                xs1[idx] = min_val + j * step; // X values constant along rows
+                ys1[idx] = min_val + i * step; // Y values constant along columns
+                zs1[idx] = 0.3 * ys1[idx] + 0.2 * xs1[idx] + 0.5;
+            }
+        }
+
+        // Surface 2: Another tilted plane that intersects the first
+        for (int i = 0; i < size; i++) {
+            for (int j = 0; j < size; j++) {
+                int idx = i * size + j;
+                xs2[idx] = min_val + j * step;
+                ys2[idx] = min_val + i * step;
+                zs2[idx] = -0.2 * ys2[idx] + 0.3 * xs2[idx] + 0.3;
+            }
+        }
+
+        initialized = true;
+    }
+
+    if (ImPlot3D::BeginPlot("Depth Buffer Test", ImVec2(-1, 0))) {
+        // Plot first surface (red with transparency)
+        ImPlot3DSpec spec1;
+        spec1.FillColor = ImVec4(1.0f, 0.0f, 0.0f, alpha);
+        spec1.FillAlpha = alpha;
+        spec1.Flags = ImPlot3DSurfaceFlags_NoLines;
+        ImPlot3D::PlotSurface("Surface 1", xs1, ys1, zs1, size, size, 0.0, 0.0, spec1);
+
+        // Plot second surface (blue with transparency)
+        ImPlot3DSpec spec2;
+        spec2.FillColor = ImVec4(0.0f, 0.0f, 1.0f, alpha);
+        spec2.FillAlpha = alpha;
+        spec2.Flags = ImPlot3DSurfaceFlags_NoLines;
+        ImPlot3D::PlotSurface("Surface 2", xs2, ys2, zs2, size, size, 0.0, 0.0, spec2);
+
+        ImPlot3D::EndPlot();
+    }
+}
+
 void DemoRealtimePlots() {
     ImGui::BulletText("Move your mouse to change the data!");
     static ScrollingBuffer sdata1, sdata2, sdata3;
@@ -1601,6 +1662,7 @@ void ShowAllDemos() {
             DemoHeader("Mesh Plots", DemoMeshPlots);
             DemoHeader("Realtime Plots", DemoRealtimePlots);
             DemoHeader("Image Plots", DemoImagePlots);
+            DemoHeader("Depth Buffer", DemoDepthBuffer);
 
             // Plot Options
             ImGui::SeparatorText("Plot Options");

--- a/implot3d_internal.h
+++ b/implot3d_internal.h
@@ -818,6 +818,7 @@ struct ImPlot3DContext {
     ImVector<ImPlot3DColormap> ColormapModifiers;
     ImPlot3DColormapData ColormapData;
     bool UseImPlot3DBackend; // Use custom ImPlot3D backend for rendering
+    ImDrawData3D DrawData;   // Draw data populated by Render()
 };
 
 //-----------------------------------------------------------------------------

--- a/implot3d_internal.h
+++ b/implot3d_internal.h
@@ -138,6 +138,15 @@ typedef void (*ImPlot3DLocator)(ImPlot3DTicker& ticker, const ImPlot3DRange& ran
 // [SECTION] Structs
 //-----------------------------------------------------------------------------
 
+typedef unsigned int ImDrawIdx3D;
+
+struct ImDrawVert3D {
+    ImPlot3DPoint pos;
+    ImVec2 uv;
+    ImU32 col;
+};
+
+// List of all triangles to render for a given plot
 struct ImDrawList3D {
     // [Internal] Define which texture should be used when rendering triangles.
     struct ImTextureBufferItem {
@@ -731,6 +740,8 @@ struct ImPlot3DPlot {
     ImPlot3DItemGroup Items;
     // 3D draw list
     ImDrawList3D DrawList;
+    ImTextureID ColorTextureID; // RGBA texture to be rendered at PlotRect
+    ImTextureID DepthTextureID; // Depth texture to be used for depth testing when rendering ColorTextureRef
     // Misc
     bool ContextClick; // True if context button was clicked (to distinguish from double click)
     bool OpenContextThisFrame;
@@ -752,6 +763,8 @@ struct ImPlot3DPlot {
         HeldPlaneIdx = -1;
         DragRotationAxis = ImPlot3DPoint(0.0, 0.0, 0.0);
         FitThisFrame = true;
+        ColorTextureID = ImTextureID_Invalid;
+        DepthTextureID = ImTextureID_Invalid;
         ContextClick = false;
         OpenContextThisFrame = false;
     }

--- a/implot3d_internal.h
+++ b/implot3d_internal.h
@@ -887,6 +887,9 @@ IMPLOT3D_API void AddTextRotated(ImDrawList* draw_list, ImVec2 pos, float angle,
 // [SECTION] Plot Utils
 //-----------------------------------------------------------------------------
 
+// Get all plots from ImPlot3DContext
+IMPLOT3D_API ImPool<ImPlot3DPlot>* GetPlots();
+
 // Gets the current plot from ImPlot3DContext
 IMPLOT3D_API ImPlot3DPlot* GetCurrentPlot();
 

--- a/implot3d_internal.h
+++ b/implot3d_internal.h
@@ -815,6 +815,7 @@ struct ImPlot3DContext {
     ImVector<ImGuiStyleMod> StyleModifiers;
     ImVector<ImPlot3DColormap> ColormapModifiers;
     ImPlot3DColormapData ColormapData;
+    bool UseImPlot3DBackend; // Use custom ImPlot3D backend for rendering
 };
 
 //-----------------------------------------------------------------------------

--- a/implot3d_internal.h
+++ b/implot3d_internal.h
@@ -742,6 +742,7 @@ struct ImPlot3DPlot {
     ImDrawList3D DrawList;
     ImTextureID ColorTextureID; // RGBA texture to be rendered at PlotRect
     ImTextureID DepthTextureID; // Depth texture to be used for depth testing when rendering ColorTextureRef
+    ImVec2 TextureSize;         // Current size of the textures (for detecting resize)
     // Misc
     bool ContextClick; // True if context button was clicked (to distinguish from double click)
     bool OpenContextThisFrame;
@@ -765,6 +766,7 @@ struct ImPlot3DPlot {
         FitThisFrame = true;
         ColorTextureID = ImTextureID_Invalid;
         DepthTextureID = ImTextureID_Invalid;
+        TextureSize = ImVec2(0.0f, 0.0f);
         ContextClick = false;
         OpenContextThisFrame = false;
     }

--- a/implot3d_internal.h
+++ b/implot3d_internal.h
@@ -154,14 +154,14 @@ struct ImDrawList3D {
         unsigned int VtxIdx;
     };
 
-    ImVector<ImDrawIdx> IdxBuffer;  // Index buffer
-    ImVector<ImDrawVert> VtxBuffer; // Vertex buffer
-    ImVector<double> ZBuffer;       // Z buffer. Depth value for each triangle
-    unsigned int _VtxCurrentIdx;    // [Internal] current vertex index
-    ImDrawVert* _VtxWritePtr; // [Internal] point within VtxBuffer.Data after each add command (to avoid using the ImVector<> operators too much)
-    ImDrawIdx* _IdxWritePtr;  // [Internal] point within IdxBuffer.Data after each add command (to avoid using the ImVector<> operators too much)
-    double* _ZWritePtr;       // [Internal] point within ZBuffer.Data after each add command (to avoid using the ImVector<> operators too much)
-    ImDrawListFlags _Flags;   // [Internal] draw list flags
+    ImVector<ImDrawIdx3D> IdxBuffer;  // Index buffer (32-bit indices)
+    ImVector<ImDrawVert3D> VtxBuffer; // Vertex buffer (stores 3D NDC positions)
+    ImVector<double> ZBuffer;         // Z buffer. Depth value for each triangle
+    unsigned int _VtxCurrentIdx;      // [Internal] current vertex index
+    ImDrawVert3D* _VtxWritePtr; // [Internal] point within VtxBuffer.Data after each add command (to avoid using the ImVector<> operators too much)
+    ImDrawIdx3D* _IdxWritePtr;  // [Internal] point within IdxBuffer.Data after each add command (to avoid using the ImVector<> operators too much)
+    double* _ZWritePtr;         // [Internal] point within ZBuffer.Data after each add command (to avoid using the ImVector<> operators too much)
+    ImDrawListFlags _Flags;     // [Internal] draw list flags
     ImVector<ImTextureBufferItem> _TextureBuffer; // [Internal] buffer for SetTexture/ResetTexture
     ImDrawListSharedData* _SharedData;            // [Internal] shared draw list data
 
@@ -191,7 +191,7 @@ struct ImDrawList3D {
         ResetTexture();
     }
 
-    constexpr static unsigned int MaxIdx() { return sizeof(ImDrawIdx) == 2 ? 65535 : 4294967295; }
+    constexpr static unsigned int MaxIdx() { return 4294967295u; } // ImDrawIdx3D is always 32-bit
 };
 
 struct ImPlot3DNextItemData {

--- a/implot3d_internal.h
+++ b/implot3d_internal.h
@@ -138,62 +138,6 @@ typedef void (*ImPlot3DLocator)(ImPlot3DTicker& ticker, const ImPlot3DRange& ran
 // [SECTION] Structs
 //-----------------------------------------------------------------------------
 
-typedef unsigned int ImDrawIdx3D;
-
-struct ImDrawVert3D {
-    ImPlot3DPoint pos;
-    ImVec2 uv;
-    ImU32 col;
-};
-
-// List of all triangles to render for a given plot
-struct ImDrawList3D {
-    // [Internal] Define which texture should be used when rendering triangles.
-    struct ImTextureBufferItem {
-        ImTextureRef TexRef;
-        unsigned int VtxIdx;
-    };
-
-    ImVector<ImDrawIdx3D> IdxBuffer;  // Index buffer (32-bit indices)
-    ImVector<ImDrawVert3D> VtxBuffer; // Vertex buffer (stores 3D NDC positions)
-    ImVector<double> ZBuffer;         // Z buffer. Depth value for each triangle
-    unsigned int _VtxCurrentIdx;      // [Internal] current vertex index
-    ImDrawVert3D* _VtxWritePtr; // [Internal] point within VtxBuffer.Data after each add command (to avoid using the ImVector<> operators too much)
-    ImDrawIdx3D* _IdxWritePtr;  // [Internal] point within IdxBuffer.Data after each add command (to avoid using the ImVector<> operators too much)
-    double* _ZWritePtr;         // [Internal] point within ZBuffer.Data after each add command (to avoid using the ImVector<> operators too much)
-    ImDrawListFlags _Flags;     // [Internal] draw list flags
-    ImVector<ImTextureBufferItem> _TextureBuffer; // [Internal] buffer for SetTexture/ResetTexture
-    ImDrawListSharedData* _SharedData;            // [Internal] shared draw list data
-
-    ImDrawList3D() {
-        _Flags = ImDrawListFlags_None;
-        _SharedData = nullptr;
-        ResetBuffers();
-    }
-
-    void PrimReserve(int idx_count, int vtx_count);
-    void PrimUnreserve(int idx_count, int vtx_count);
-
-    void SetTexture(ImTextureRef tex_ref);
-    void ResetTexture();
-
-    void SortedMoveToImGuiDrawList();
-
-    void ResetBuffers() {
-        IdxBuffer.clear();
-        VtxBuffer.clear();
-        ZBuffer.clear();
-        _VtxCurrentIdx = 0;
-        _VtxWritePtr = VtxBuffer.Data;
-        _IdxWritePtr = IdxBuffer.Data;
-        _ZWritePtr = ZBuffer.Data;
-        _TextureBuffer.clear();
-        ResetTexture();
-    }
-
-    constexpr static unsigned int MaxIdx() { return 4294967295u; } // ImDrawIdx3D is always 32-bit
-};
-
 struct ImPlot3DNextItemData {
     ImPlot3DSpec Spec;
     bool RenderLine;
@@ -740,9 +684,6 @@ struct ImPlot3DPlot {
     ImPlot3DItemGroup Items;
     // 3D draw list
     ImDrawList3D DrawList;
-    ImTextureID ColorTextureID; // RGBA texture to be rendered at PlotRect
-    ImTextureID DepthTextureID; // Depth texture to be used for depth testing when rendering ColorTextureRef
-    ImVec2 TextureSize;         // Current size of the textures (for detecting resize)
     // Misc
     bool ContextClick; // True if context button was clicked (to distinguish from double click)
     bool OpenContextThisFrame;
@@ -764,9 +705,6 @@ struct ImPlot3DPlot {
         HeldPlaneIdx = -1;
         DragRotationAxis = ImPlot3DPoint(0.0, 0.0, 0.0);
         FitThisFrame = true;
-        ColorTextureID = ImTextureID_Invalid;
-        DepthTextureID = ImTextureID_Invalid;
-        TextureSize = ImVec2(0.0f, 0.0f);
         ContextClick = false;
         OpenContextThisFrame = false;
     }

--- a/implot3d_items.cpp
+++ b/implot3d_items.cpp
@@ -318,6 +318,9 @@ IMPLOT3D_INLINE void PrimLine(ImDrawList3D& draw_list_3d, const ImPlot3DPoint& P
     draw_list_3d._ZWritePtr[0] = z;
     draw_list_3d._ZWritePtr[1] = z;
     draw_list_3d._ZWritePtr += 2;
+
+    // Add triangle command (6 indices = 2 triangles for the line quad)
+    draw_list_3d.AddTriangleCmd(6);
 }
 
 //-----------------------------------------------------------------------------
@@ -383,6 +386,10 @@ template <class _Getter> struct RendererMarkersFill : RendererBase {
         }
         // Update vertex count
         draw_list_3d._VtxCurrentIdx += (ImDrawIdx)Count;
+
+        // Add triangle command
+        draw_list_3d.AddTriangleCmd((Count - 2) * 3);
+
         return true;
     }
     const _Getter& Getter;
@@ -585,12 +592,15 @@ template <class _Getter> struct RendererTriangleFill : RendererBase {
         draw_list_3d._IdxWritePtr[1] = (ImDrawIdx)(draw_list_3d._VtxCurrentIdx + 1);
         draw_list_3d._IdxWritePtr[2] = (ImDrawIdx)(draw_list_3d._VtxCurrentIdx + 2);
         draw_list_3d._IdxWritePtr += 3;
-        // 1 Z per vertex
+        // 1 Z per triangle
         draw_list_3d._ZWritePtr[0] = GetPointDepth((p_plot[0] + p_plot[1] + p_plot[2]) / 3);
         draw_list_3d._ZWritePtr++;
 
         // Update vertex count
         draw_list_3d._VtxCurrentIdx += 3;
+
+        // Add triangle command
+        draw_list_3d.AddTriangleCmd(3);
 
         return true;
     }
@@ -661,6 +671,9 @@ template <class _Getter> struct RendererQuadFill : RendererBase {
 
         // Update vertex count
         draw_list_3d._VtxCurrentIdx += 4;
+
+        // Add triangle command (6 indices = 2 triangles)
+        draw_list_3d.AddTriangleCmd(6);
 
         return true;
     }
@@ -736,6 +749,9 @@ template <class _Getter> struct RendererQuadImage : RendererBase {
 
         // Update vertex count
         draw_list_3d._VtxCurrentIdx += 4;
+
+        // Add triangle command
+        draw_list_3d.AddTriangleCmd(6);
 
         // Reset texture ID
         draw_list_3d.ResetTexture();
@@ -846,6 +862,9 @@ template <class _Getter> struct RendererSurfaceFill : RendererBase {
 
         // Update vertex count
         draw_list_3d._VtxCurrentIdx += 4;
+
+        // Add triangle command
+        draw_list_3d.AddTriangleCmd(6);
 
         return true;
     }
@@ -1016,8 +1035,7 @@ template <template <class> class _Renderer, class _Getter, typename... Args> voi
     unsigned int prims_to_render = ImMin(renderer.Prims, (ImDrawList3D::MaxIdx() - draw_list_3d._VtxCurrentIdx) / renderer.VtxConsumed);
 
     // Reserve vertices, indices, and depth values to render the primitives
-    draw_list_3d.PrimReserve(prims_to_render * renderer.IdxConsumed, prims_to_render * renderer.VtxConsumed,
-                             prims_to_render * renderer.ZConsumed);
+    draw_list_3d.PrimReserve(prims_to_render * renderer.IdxConsumed, prims_to_render * renderer.VtxConsumed, prims_to_render * renderer.ZConsumed);
 
     // Initialize renderer
     renderer.Init(draw_list_3d);

--- a/implot3d_items.cpp
+++ b/implot3d_items.cpp
@@ -14,7 +14,6 @@
 // [SECTION] Macros & Defines
 // [SECTION] Template instantiation utility
 // [SECTION] Item Utils
-// [SECTION] Draw Utils
 // [SECTION] Renderers
 // [SECTION] Indexers
 // [SECTION] Getters
@@ -46,9 +45,6 @@
 // [SECTION] Macros & Defines
 //-----------------------------------------------------------------------------
 
-#define SQRT_1_2 0.70710678118f
-#define SQRT_3_2 0.86602540378f
-
 // clang-format off
 #ifndef IMPLOT3D_NO_FORCE_INLINE
     #ifdef _MSC_VER
@@ -78,19 +74,6 @@
             VY *= inv_len;                                                                                                                           \
         }                                                                                                                                            \
     } while (0)
-
-IMPLOT3D_INLINE void GetLineRenderProps(const ImDrawList3D& draw_list_3d, float& half_weight, ImVec2& tex_uv0, ImVec2& tex_uv1) {
-    const bool aa = ImPlot3D::ImHasFlag(draw_list_3d._Flags, ImDrawListFlags_AntiAliasedLines) &&
-                    ImPlot3D::ImHasFlag(draw_list_3d._Flags, ImDrawListFlags_AntiAliasedLinesUseTex);
-    if (aa) {
-        ImVec4 tex_uvs = draw_list_3d._SharedData->TexUvLines[(int)(half_weight * 2)];
-        tex_uv0 = ImVec2(tex_uvs.x, tex_uvs.y);
-        tex_uv1 = ImVec2(tex_uvs.z, tex_uvs.w);
-        half_weight += 1;
-    } else {
-        tex_uv0 = tex_uv1 = draw_list_3d._SharedData->TexUvWhitePixel;
-    }
-}
 
 //-----------------------------------------------------------------------------
 // [SECTION] Template instantiation utility
@@ -277,53 +260,6 @@ void BustItemCache() {
 }
 
 //-----------------------------------------------------------------------------
-// [SECTION] Draw Utils
-//-----------------------------------------------------------------------------
-
-IMPLOT3D_INLINE void PrimLine(ImDrawList3D& draw_list_3d, const ImPlot3DPoint& P1_ndc, const ImPlot3DPoint& P2_ndc, float half_weight, ImU32 col,
-                              const ImVec2& tex_uv0, const ImVec2& tex_uv1, double z) {
-    // TODO Compute perpendicular direction in NDC space
-    // Scale the half_weight from pixel units to NDC units
-    const float ndc_half_weight = 0.01f * half_weight;
-
-    float dx = (float)(P2_ndc.x - P1_ndc.x);
-    float dy = (float)(P2_ndc.y - P1_ndc.y);
-    IMPLOT3D_NORMALIZE2F(dx, dy);
-    dx *= ndc_half_weight;
-    dy *= ndc_half_weight;
-
-    // Create the 4 corners of the line quad
-    draw_list_3d._VtxWritePtr[0].pos = ImPlot3DPoint(P1_ndc.x + dy, P1_ndc.y - dx, P1_ndc.z);
-    draw_list_3d._VtxWritePtr[0].uv = tex_uv0;
-    draw_list_3d._VtxWritePtr[0].col = col;
-    draw_list_3d._VtxWritePtr[1].pos = ImPlot3DPoint(P2_ndc.x + dy, P2_ndc.y - dx, P2_ndc.z);
-    draw_list_3d._VtxWritePtr[1].uv = tex_uv0;
-    draw_list_3d._VtxWritePtr[1].col = col;
-    draw_list_3d._VtxWritePtr[2].pos = ImPlot3DPoint(P2_ndc.x - dy, P2_ndc.y + dx, P2_ndc.z);
-    draw_list_3d._VtxWritePtr[2].uv = tex_uv1;
-    draw_list_3d._VtxWritePtr[2].col = col;
-    draw_list_3d._VtxWritePtr[3].pos = ImPlot3DPoint(P1_ndc.x - dy, P1_ndc.y + dx, P1_ndc.z);
-    draw_list_3d._VtxWritePtr[3].uv = tex_uv1;
-    draw_list_3d._VtxWritePtr[3].col = col;
-    draw_list_3d._VtxWritePtr += 4;
-
-    draw_list_3d._IdxWritePtr[0] = (ImDrawIdx3D)(draw_list_3d._VtxCurrentIdx);
-    draw_list_3d._IdxWritePtr[1] = (ImDrawIdx3D)(draw_list_3d._VtxCurrentIdx + 1);
-    draw_list_3d._IdxWritePtr[2] = (ImDrawIdx3D)(draw_list_3d._VtxCurrentIdx + 2);
-    draw_list_3d._IdxWritePtr[3] = (ImDrawIdx3D)(draw_list_3d._VtxCurrentIdx);
-    draw_list_3d._IdxWritePtr[4] = (ImDrawIdx3D)(draw_list_3d._VtxCurrentIdx + 2);
-    draw_list_3d._IdxWritePtr[5] = (ImDrawIdx3D)(draw_list_3d._VtxCurrentIdx + 3);
-    draw_list_3d._IdxWritePtr += 6;
-    draw_list_3d._VtxCurrentIdx += 4;
-    draw_list_3d._ZWritePtr[0] = z;
-    draw_list_3d._ZWritePtr[1] = z;
-    draw_list_3d._ZWritePtr += 2;
-
-    // Add triangle command (6 indices = 2 triangles for the line quad)
-    draw_list_3d.AddTriangleCmd(6);
-}
-
-//-----------------------------------------------------------------------------
 // [SECTION] Renderers
 //-----------------------------------------------------------------------------
 
@@ -352,95 +288,14 @@ struct RendererBase {
     const unsigned int ZConsumed;   // Number of depth values consumed per primitive
 };
 
-template <class _Getter> struct RendererMarkersFill : RendererBase {
-    RendererMarkersFill(const _Getter& getter, const ImVec2* marker, int count, float size, ImU32 col)
-        : RendererBase(getter.Count, (count - 2) * 3, count, count - 2), Getter(getter), Marker(marker), Count(count), Size(size), Col(col) {}
-
-    void Init(ImDrawList3D& draw_list_3d) const { UV = draw_list_3d._SharedData->TexUvWhitePixel; }
-
-    IMPLOT3D_INLINE bool Render(ImDrawList3D& draw_list_3d, const ImPlot3DBox& cull_box, int prim) const {
-        ImPlot3DPoint p_plot = Getter(prim);
-        if (!cull_box.Contains(p_plot))
-            return false;
-        ImPlot3DPoint p_ndc = PlotToNDC(p_plot);
-        // Use a small hardcoded marker size in NDC for now. TODO do it properly
-        const float ndc_marker_size = 0.03f;
-        // 3 vertices per triangle
-        for (int i = 0; i < Count; i++) {
-            draw_list_3d._VtxWritePtr[0].pos =
-                ImPlot3DPoint(p_ndc.x + Marker[i].x * ndc_marker_size, p_ndc.y + Marker[i].y * ndc_marker_size, p_ndc.z);
-            draw_list_3d._VtxWritePtr[0].uv = UV;
-            draw_list_3d._VtxWritePtr[0].col = Col;
-            draw_list_3d._VtxWritePtr++;
-        }
-        // 3 indices per triangle
-        for (int i = 2; i < Count; i++) {
-            // Indices
-            draw_list_3d._IdxWritePtr[0] = (ImDrawIdx)(draw_list_3d._VtxCurrentIdx);
-            draw_list_3d._IdxWritePtr[1] = (ImDrawIdx)(draw_list_3d._VtxCurrentIdx + i - 1);
-            draw_list_3d._IdxWritePtr[2] = (ImDrawIdx)(draw_list_3d._VtxCurrentIdx + i);
-            draw_list_3d._IdxWritePtr += 3;
-            // Z
-            draw_list_3d._ZWritePtr[0] = GetPointDepth(p_plot);
-            draw_list_3d._ZWritePtr++;
-        }
-        // Update vertex count
-        draw_list_3d._VtxCurrentIdx += (ImDrawIdx)Count;
-
-        // Add triangle command
-        draw_list_3d.AddTriangleCmd((Count - 2) * 3);
-
-        return true;
-    }
-    const _Getter& Getter;
-    const ImVec2* Marker;
-    const int Count;
-    const float Size;
-    const ImU32 Col;
-    mutable ImVec2 UV;
-};
-
-template <class _Getter> struct RendererMarkersLine : RendererBase {
-    RendererMarkersLine(const _Getter& getter, const ImVec2* marker, int count, float size, float weight, ImU32 col)
-        : RendererBase(getter.Count, count / 2 * 6, count / 2 * 4, count / 2 * 2), Getter(getter), Marker(marker), Count(count),
-          HalfWeight(ImMax(1.0f, weight) * 0.5f), Size(size), Col(col) {}
-
-    void Init(ImDrawList3D& draw_list_3d) const { GetLineRenderProps(draw_list_3d, HalfWeight, UV0, UV1); }
-
-    IMPLOT3D_INLINE bool Render(ImDrawList3D& draw_list_3d, const ImPlot3DBox& cull_box, int prim) const {
-        ImPlot3DPoint p_plot = Getter(prim);
-        if (!cull_box.Contains(p_plot))
-            return false;
-        ImPlot3DPoint p_ndc = PlotToNDC(p_plot);
-        // Use a small hardcoded marker size in NDC for now
-        const float ndc_marker_size = 0.03f;
-        for (int i = 0; i < Count; i = i + 2) {
-            // Compute marker line endpoints in NDC space
-            ImPlot3DPoint p1_ndc = ImPlot3DPoint(p_ndc.x + Marker[i].x * ndc_marker_size, p_ndc.y + Marker[i].y * ndc_marker_size, p_ndc.z);
-            ImPlot3DPoint p2_ndc = ImPlot3DPoint(p_ndc.x + Marker[i + 1].x * ndc_marker_size, p_ndc.y + Marker[i + 1].y * ndc_marker_size, p_ndc.z);
-            PrimLine(draw_list_3d, p1_ndc, p2_ndc, HalfWeight, Col, UV0, UV1, GetPointDepth(p_plot));
-        }
-        return true;
-    }
-
-    const _Getter& Getter;
-    const ImVec2* Marker;
-    const int Count;
-    mutable float HalfWeight;
-    const float Size;
-    const ImU32 Col;
-    mutable ImVec2 UV0;
-    mutable ImVec2 UV1;
-};
-
 template <class _Getter> struct RendererLineStrip : RendererBase {
     RendererLineStrip(const _Getter& getter, ImU32 col, float weight)
-        : RendererBase(getter.Count - 1, 6, 4, 2), Getter(getter), Col(col), HalfWeight(ImMax(1.0f, weight) * 0.5f) {
+        : RendererBase(getter.Count - 1, 0, 0, 0), Getter(getter), Col(col), Weight(ImMax(1.0f, weight)) {
         // Initialize the first point in plot coordinates
         P1_plot = Getter(0);
     }
 
-    void Init(ImDrawList3D& draw_list_3d) const { GetLineRenderProps(draw_list_3d, HalfWeight, UV0, UV1); }
+    void Init(ImDrawList3D&) const {}
 
     IMPLOT3D_INLINE bool Render(ImDrawList3D& draw_list_3d, const ImPlot3DBox& cull_box, int prim) const {
         ImPlot3DPoint P2_plot = Getter(prim + 1);
@@ -454,31 +309,28 @@ template <class _Getter> struct RendererLineStrip : RendererBase {
             ImPlot3DPoint P1_ndc = PlotToNDC(P1_clipped);
             ImPlot3DPoint P2_ndc = PlotToNDC(P2_clipped);
             // Render the line segment
-            PrimLine(draw_list_3d, P1_ndc, P2_ndc, HalfWeight, Col, UV0, UV1, GetPointDepth((P1_plot + P2_plot) * 0.5));
+            draw_list_3d.AddLine(P1_ndc, P2_ndc, GetPointDepth((P1_plot + P2_plot) * 0.5), Col, Col, Weight);
         }
 
         // Update for next segment
         P1_plot = P2_plot;
-
         return visible;
     }
 
     const _Getter& Getter;
     const ImU32 Col;
-    mutable float HalfWeight;
+    const float Weight;
     mutable ImPlot3DPoint P1_plot;
-    mutable ImVec2 UV0;
-    mutable ImVec2 UV1;
 };
 
 template <class _Getter> struct RendererLineStripSkip : RendererBase {
     RendererLineStripSkip(const _Getter& getter, ImU32 col, float weight)
-        : RendererBase(getter.Count - 1, 6, 4, 2), Getter(getter), Col(col), HalfWeight(ImMax(1.0f, weight) * 0.5f) {
+        : RendererBase(getter.Count - 1, 0, 0, 0), Getter(getter), Col(col), Weight(ImMax(1.0f, weight)) {
         // Initialize the first point in plot coordinates
         P1_plot = Getter(0);
     }
 
-    void Init(ImDrawList3D& draw_list_3d) const { GetLineRenderProps(draw_list_3d, HalfWeight, UV0, UV1); }
+    void Init(ImDrawList3D&) const {}
 
     IMPLOT3D_INLINE bool Render(ImDrawList3D& draw_list_3d, const ImPlot3DBox& cull_box, int prim) const {
         // Get the next point in plot coordinates
@@ -487,7 +339,6 @@ template <class _Getter> struct RendererLineStripSkip : RendererBase {
 
         // Check for NaNs in P1_plot and P2_plot
         if (!ImNan(P1_plot.x) && !ImNan(P1_plot.y) && !ImNan(P1_plot.z) && !ImNan(P2_plot.x) && !ImNan(P2_plot.y) && !ImNan(P2_plot.z)) {
-
             // Clip the line segment to the culling box
             ImPlot3DPoint P1_clipped, P2_clipped;
             visible = cull_box.ClipLineSegment(P1_plot, P2_plot, P1_clipped, P2_clipped);
@@ -497,7 +348,7 @@ template <class _Getter> struct RendererLineStripSkip : RendererBase {
                 ImPlot3DPoint P1_ndc = PlotToNDC(P1_clipped);
                 ImPlot3DPoint P2_ndc = PlotToNDC(P2_clipped);
                 // Render the line segment
-                PrimLine(draw_list_3d, P1_ndc, P2_ndc, HalfWeight, Col, UV0, UV1, GetPointDepth((P1_plot + P2_plot) * 0.5));
+                draw_list_3d.AddLine(P1_ndc, P2_ndc, GetPointDepth((P1_plot + P2_plot) * 0.5), Col, Col, Weight);
             }
         }
 
@@ -510,17 +361,15 @@ template <class _Getter> struct RendererLineStripSkip : RendererBase {
 
     const _Getter& Getter;
     const ImU32 Col;
-    mutable float HalfWeight;
+    const float Weight;
     mutable ImPlot3DPoint P1_plot;
-    mutable ImVec2 UV0;
-    mutable ImVec2 UV1;
 };
 
 template <class _Getter> struct RendererLineSegments : RendererBase {
     RendererLineSegments(const _Getter& getter, ImU32 col, float weight)
-        : RendererBase(getter.Count / 2, 6, 4, 2), Getter(getter), Col(col), HalfWeight(ImMax(1.0f, weight) * 0.5f) {}
+        : RendererBase(getter.Count / 2, 0, 0, 0), Getter(getter), Col(col), Weight(ImMax(1.0f, weight)) {}
 
-    void Init(ImDrawList3D& draw_list_3d) const { GetLineRenderProps(draw_list_3d, HalfWeight, UV0, UV1); }
+    void Init(ImDrawList3D&) const {}
 
     IMPLOT3D_INLINE bool Render(ImDrawList3D& draw_list_3d, const ImPlot3DBox& cull_box, int prim) const {
         // Get the segment's endpoints in plot coordinates
@@ -529,7 +378,6 @@ template <class _Getter> struct RendererLineSegments : RendererBase {
 
         // Check for NaNs in P1_plot and P2_plot
         if (!ImNan(P1_plot.x) && !ImNan(P1_plot.y) && !ImNan(P1_plot.z) && !ImNan(P2_plot.x) && !ImNan(P2_plot.y) && !ImNan(P2_plot.z)) {
-
             // Clip the line segment to the culling box
             ImPlot3DPoint P1_clipped, P2_clipped;
             bool visible = cull_box.ClipLineSegment(P1_plot, P2_plot, P1_clipped, P2_clipped);
@@ -539,7 +387,7 @@ template <class _Getter> struct RendererLineSegments : RendererBase {
                 ImPlot3DPoint P1_ndc = PlotToNDC(P1_clipped);
                 ImPlot3DPoint P2_ndc = PlotToNDC(P2_clipped);
                 // Render the line segment
-                PrimLine(draw_list_3d, P1_ndc, P2_ndc, HalfWeight, Col, UV0, UV1, GetPointDepth((P1_plot + P2_plot) * 0.5));
+                draw_list_3d.AddLine(P1_ndc, P2_ndc, GetPointDepth((P1_plot + P2_plot) * 0.5), Col, Col, Weight);
             }
             return visible;
         }
@@ -549,9 +397,7 @@ template <class _Getter> struct RendererLineSegments : RendererBase {
 
     const _Getter& Getter;
     const ImU32 Col;
-    mutable float HalfWeight;
-    mutable ImVec2 UV0;
-    mutable ImVec2 UV1;
+    const float Weight;
 };
 
 template <class _Getter> struct RendererTriangleFill : RendererBase {
@@ -1017,7 +863,7 @@ struct GetterMeshTriangles {
 // [SECTION] RenderPrimitives
 //-----------------------------------------------------------------------------
 
-/// Renders primitive shapes
+/// Renders triangle-based primitive shapes (surfaces, fills)
 template <template <class> class _Renderer, class _Getter, typename... Args> void RenderPrimitives(const _Getter& getter, Args... args) {
     _Renderer<_Getter> renderer(getter, args...);
     ImPlot3DPlot& plot = *GetCurrentPlot();
@@ -1049,92 +895,50 @@ template <template <class> class _Renderer, class _Getter, typename... Args> voi
     draw_list_3d.PrimUnreserve(num_culled * renderer.IdxConsumed, num_culled * renderer.VtxConsumed, num_culled * renderer.ZConsumed);
 }
 
+/// Renders line segment primitives (pushes to LineBuffer, no tessellation)
+template <template <class> class _Renderer, class _Getter, typename... Args> void RenderLinePrimitives(const _Getter& getter, Args... args) {
+    _Renderer<_Getter> renderer(getter, args...);
+    ImPlot3DPlot& plot = *GetCurrentPlot();
+    ImDrawList3D& draw_list_3d = plot.DrawList;
+    ImPlot3DBox cull_box;
+    if (ImHasFlag(plot.Flags, ImPlot3DFlags_NoClip)) {
+        cull_box.Min = ImPlot3DPoint(-HUGE_VAL, -HUGE_VAL, -HUGE_VAL);
+        cull_box.Max = ImPlot3DPoint(HUGE_VAL, HUGE_VAL, HUGE_VAL);
+    } else {
+        cull_box.Min = plot.RangeMin();
+        cull_box.Max = plot.RangeMax();
+    }
+
+    renderer.Init(draw_list_3d);
+    for (unsigned int i = 0; i < renderer.Prims; i++)
+        renderer.Render(draw_list_3d, cull_box, i);
+}
+
 //-----------------------------------------------------------------------------
 // [SECTION] Markers
 //-----------------------------------------------------------------------------
 
-static const ImVec2 MARKER_FILL_CIRCLE[10] = {ImVec2(1.0f, 0.0f),
-                                              ImVec2(0.809017f, 0.58778524f),
-                                              ImVec2(0.30901697f, 0.95105654f),
-                                              ImVec2(-0.30901703f, 0.9510565f),
-                                              ImVec2(-0.80901706f, 0.5877852f),
-                                              ImVec2(-1.0f, 0.0f),
-                                              ImVec2(-0.80901694f, -0.58778536f),
-                                              ImVec2(-0.3090171f, -0.9510565f),
-                                              ImVec2(0.30901712f, -0.9510565f),
-                                              ImVec2(0.80901694f, -0.5877853f)};
-static const ImVec2 MARKER_FILL_SQUARE[4] = {ImVec2(SQRT_1_2, SQRT_1_2), ImVec2(SQRT_1_2, -SQRT_1_2), ImVec2(-SQRT_1_2, -SQRT_1_2),
-                                             ImVec2(-SQRT_1_2, SQRT_1_2)};
-static const ImVec2 MARKER_FILL_DIAMOND[4] = {ImVec2(1, 0), ImVec2(0, -1), ImVec2(-1, 0), ImVec2(0, 1)};
-static const ImVec2 MARKER_FILL_UP[3] = {ImVec2(SQRT_3_2, 0.5f), ImVec2(0, -1), ImVec2(-SQRT_3_2, 0.5f)};
-static const ImVec2 MARKER_FILL_DOWN[3] = {ImVec2(SQRT_3_2, -0.5f), ImVec2(0, 1), ImVec2(-SQRT_3_2, -0.5f)};
-static const ImVec2 MARKER_FILL_LEFT[3] = {ImVec2(-1, 0), ImVec2(0.5, SQRT_3_2), ImVec2(0.5, -SQRT_3_2)};
-static const ImVec2 MARKER_FILL_RIGHT[3] = {ImVec2(1, 0), ImVec2(-0.5, SQRT_3_2), ImVec2(-0.5, -SQRT_3_2)};
-static const ImVec2 MARKER_LINE_CIRCLE[20] = {ImVec2(1.0f, 0.0f),
-                                              ImVec2(0.809017f, 0.58778524f),
-                                              ImVec2(0.809017f, 0.58778524f),
-                                              ImVec2(0.30901697f, 0.95105654f),
-                                              ImVec2(0.30901697f, 0.95105654f),
-                                              ImVec2(-0.30901703f, 0.9510565f),
-                                              ImVec2(-0.30901703f, 0.9510565f),
-                                              ImVec2(-0.80901706f, 0.5877852f),
-                                              ImVec2(-0.80901706f, 0.5877852f),
-                                              ImVec2(-1.0f, 0.0f),
-                                              ImVec2(-1.0f, 0.0f),
-                                              ImVec2(-0.80901694f, -0.58778536f),
-                                              ImVec2(-0.80901694f, -0.58778536f),
-                                              ImVec2(-0.3090171f, -0.9510565f),
-                                              ImVec2(-0.3090171f, -0.9510565f),
-                                              ImVec2(0.30901712f, -0.9510565f),
-                                              ImVec2(0.30901712f, -0.9510565f),
-                                              ImVec2(0.80901694f, -0.5877853f),
-                                              ImVec2(0.80901694f, -0.5877853f),
-                                              ImVec2(1.0f, 0.0f)};
-static const ImVec2 MARKER_LINE_SQUARE[8] = {ImVec2(SQRT_1_2, SQRT_1_2),   ImVec2(SQRT_1_2, -SQRT_1_2),  ImVec2(SQRT_1_2, -SQRT_1_2),
-                                             ImVec2(-SQRT_1_2, -SQRT_1_2), ImVec2(-SQRT_1_2, -SQRT_1_2), ImVec2(-SQRT_1_2, SQRT_1_2),
-                                             ImVec2(-SQRT_1_2, SQRT_1_2),  ImVec2(SQRT_1_2, SQRT_1_2)};
-static const ImVec2 MARKER_LINE_DIAMOND[8] = {ImVec2(1, 0),  ImVec2(0, -1), ImVec2(0, -1), ImVec2(-1, 0),
-                                              ImVec2(-1, 0), ImVec2(0, 1),  ImVec2(0, 1),  ImVec2(1, 0)};
-static const ImVec2 MARKER_LINE_UP[6] = {ImVec2(SQRT_3_2, 0.5f),  ImVec2(0, -1),           ImVec2(0, -1),
-                                         ImVec2(-SQRT_3_2, 0.5f), ImVec2(-SQRT_3_2, 0.5f), ImVec2(SQRT_3_2, 0.5f)};
-static const ImVec2 MARKER_LINE_DOWN[6] = {ImVec2(SQRT_3_2, -0.5f),  ImVec2(0, 1),           ImVec2(0, 1), ImVec2(-SQRT_3_2, -0.5f),
-                                           ImVec2(-SQRT_3_2, -0.5f), ImVec2(SQRT_3_2, -0.5f)};
-static const ImVec2 MARKER_LINE_LEFT[6] = {ImVec2(-1, 0),          ImVec2(0.5, SQRT_3_2),  ImVec2(0.5, SQRT_3_2),
-                                           ImVec2(0.5, -SQRT_3_2), ImVec2(0.5, -SQRT_3_2), ImVec2(-1, 0)};
-static const ImVec2 MARKER_LINE_RIGHT[6] = {
-    ImVec2(1, 0), ImVec2(-0.5, SQRT_3_2), ImVec2(-0.5, SQRT_3_2), ImVec2(-0.5, -SQRT_3_2), ImVec2(-0.5, -SQRT_3_2), ImVec2(1, 0)};
-static const ImVec2 MARKER_LINE_ASTERISK[6] = {ImVec2(-SQRT_3_2, -0.5f), ImVec2(SQRT_3_2, 0.5f), ImVec2(-SQRT_3_2, 0.5f),
-                                               ImVec2(SQRT_3_2, -0.5f),  ImVec2(0, -1),          ImVec2(0, 1)};
-static const ImVec2 MARKER_LINE_PLUS[4] = {ImVec2(-1, 0), ImVec2(1, 0), ImVec2(0, -1), ImVec2(0, 1)};
-static const ImVec2 MARKER_LINE_CROSS[4] = {ImVec2(-SQRT_1_2, -SQRT_1_2), ImVec2(SQRT_1_2, SQRT_1_2), ImVec2(SQRT_1_2, -SQRT_1_2),
-                                            ImVec2(-SQRT_1_2, SQRT_1_2)};
-
 template <typename _Getter> void RenderMarkers(const _Getter& getter, ImPlot3DMarker marker, float size, bool rend_fill, ImU32 col_fill,
                                                bool rend_line, ImU32 col_line, float weight) {
-    if (rend_fill) {
-        switch (marker) {
-            case ImPlot3DMarker_Circle: RenderPrimitives<RendererMarkersFill>(getter, MARKER_FILL_CIRCLE, 10, size, col_fill); break;
-            case ImPlot3DMarker_Square: RenderPrimitives<RendererMarkersFill>(getter, MARKER_FILL_SQUARE, 4, size, col_fill); break;
-            case ImPlot3DMarker_Diamond: RenderPrimitives<RendererMarkersFill>(getter, MARKER_FILL_DIAMOND, 4, size, col_fill); break;
-            case ImPlot3DMarker_Up: RenderPrimitives<RendererMarkersFill>(getter, MARKER_FILL_UP, 3, size, col_fill); break;
-            case ImPlot3DMarker_Down: RenderPrimitives<RendererMarkersFill>(getter, MARKER_FILL_DOWN, 3, size, col_fill); break;
-            case ImPlot3DMarker_Left: RenderPrimitives<RendererMarkersFill>(getter, MARKER_FILL_LEFT, 3, size, col_fill); break;
-            case ImPlot3DMarker_Right: RenderPrimitives<RendererMarkersFill>(getter, MARKER_FILL_RIGHT, 3, size, col_fill); break;
-        }
+    ImPlot3DPlot& plot = *GetCurrentPlot();
+    ImDrawList3D& draw_list_3d = plot.DrawList;
+    ImPlot3DBox cull_box;
+    if (ImHasFlag(plot.Flags, ImPlot3DFlags_NoClip)) {
+        cull_box.Min = ImPlot3DPoint(-HUGE_VAL, -HUGE_VAL, -HUGE_VAL);
+        cull_box.Max = ImPlot3DPoint(HUGE_VAL, HUGE_VAL, HUGE_VAL);
+    } else {
+        cull_box.Min = plot.RangeMin();
+        cull_box.Max = plot.RangeMax();
     }
-    if (rend_line) {
-        switch (marker) {
-            case ImPlot3DMarker_Circle: RenderPrimitives<RendererMarkersLine>(getter, MARKER_LINE_CIRCLE, 20, size, weight, col_line); break;
-            case ImPlot3DMarker_Square: RenderPrimitives<RendererMarkersLine>(getter, MARKER_LINE_SQUARE, 8, size, weight, col_line); break;
-            case ImPlot3DMarker_Diamond: RenderPrimitives<RendererMarkersLine>(getter, MARKER_LINE_DIAMOND, 8, size, weight, col_line); break;
-            case ImPlot3DMarker_Up: RenderPrimitives<RendererMarkersLine>(getter, MARKER_LINE_UP, 6, size, weight, col_line); break;
-            case ImPlot3DMarker_Down: RenderPrimitives<RendererMarkersLine>(getter, MARKER_LINE_DOWN, 6, size, weight, col_line); break;
-            case ImPlot3DMarker_Left: RenderPrimitives<RendererMarkersLine>(getter, MARKER_LINE_LEFT, 6, size, weight, col_line); break;
-            case ImPlot3DMarker_Right: RenderPrimitives<RendererMarkersLine>(getter, MARKER_LINE_RIGHT, 6, size, weight, col_line); break;
-            case ImPlot3DMarker_Asterisk: RenderPrimitives<RendererMarkersLine>(getter, MARKER_LINE_ASTERISK, 6, size, weight, col_line); break;
-            case ImPlot3DMarker_Plus: RenderPrimitives<RendererMarkersLine>(getter, MARKER_LINE_PLUS, 4, size, weight, col_line); break;
-            case ImPlot3DMarker_Cross: RenderPrimitives<RendererMarkersLine>(getter, MARKER_LINE_CROSS, 4, size, weight, col_line); break;
-        }
+
+    const ImU32 no_col = IM_COL32(0, 0, 0, 0);
+    for (int i = 0; i < getter.Count; i++) {
+        ImPlot3DPoint p_plot = getter(i);
+        if (!cull_box.Contains(p_plot))
+            continue;
+        ImPlot3DPoint p_ndc = PlotToNDC(p_plot);
+        double z = GetPointDepth(p_plot);
+        draw_list_3d.AddMarker(p_ndc, z, rend_fill ? col_fill : no_col, rend_line ? col_line : no_col, size, weight, marker);
     }
 }
 
@@ -1182,17 +986,17 @@ template <typename _Getter> void PlotLineEx(const char* label_id, const _Getter&
         if (getter.Count >= 2 && n.RenderLine) {
             const ImU32 col_line = ImGui::GetColorU32(s.LineColor);
             if (ImHasFlag(spec.Flags, ImPlot3DLineFlags_Segments)) {
-                RenderPrimitives<RendererLineSegments>(getter, col_line, s.LineWeight);
+                RenderLinePrimitives<RendererLineSegments>(getter, col_line, s.LineWeight);
             } else if (ImHasFlag(spec.Flags, ImPlot3DLineFlags_Loop)) {
                 if (ImHasFlag(spec.Flags, ImPlot3DLineFlags_SkipNaN))
-                    RenderPrimitives<RendererLineStripSkip>(GetterLoop<_Getter>(getter), col_line, s.LineWeight);
+                    RenderLinePrimitives<RendererLineStripSkip>(GetterLoop<_Getter>(getter), col_line, s.LineWeight);
                 else
-                    RenderPrimitives<RendererLineStrip>(GetterLoop<_Getter>(getter), col_line, s.LineWeight);
+                    RenderLinePrimitives<RendererLineStrip>(GetterLoop<_Getter>(getter), col_line, s.LineWeight);
             } else {
                 if (ImHasFlag(spec.Flags, ImPlot3DLineFlags_SkipNaN))
-                    RenderPrimitives<RendererLineStripSkip>(getter, col_line, s.LineWeight);
+                    RenderLinePrimitives<RendererLineStripSkip>(getter, col_line, s.LineWeight);
                 else
-                    RenderPrimitives<RendererLineStrip>(getter, col_line, s.LineWeight);
+                    RenderLinePrimitives<RendererLineStrip>(getter, col_line, s.LineWeight);
             }
         }
 
@@ -1239,7 +1043,7 @@ template <typename _Getter> void PlotTriangleEx(const char* label_id, const _Get
         // Render lines
         if (getter.Count >= 2 && n.RenderLine && !ImHasFlag(spec.Flags, ImPlot3DTriangleFlags_NoLines)) {
             const ImU32 col_line = ImGui::GetColorU32(s.LineColor);
-            RenderPrimitives<RendererLineSegments>(GetterTriangleLines<_Getter>(getter), col_line, s.LineWeight);
+            RenderLinePrimitives<RendererLineSegments>(GetterTriangleLines<_Getter>(getter), col_line, s.LineWeight);
         }
 
         // Render markers
@@ -1286,7 +1090,7 @@ template <typename _Getter> void PlotQuadEx(const char* label_id, const _Getter&
         // Render lines
         if (getter.Count >= 2 && n.RenderLine && !ImHasFlag(spec.Flags, ImPlot3DQuadFlags_NoLines)) {
             const ImU32 col_line = ImGui::GetColorU32(s.LineColor);
-            RenderPrimitives<RendererLineSegments>(GetterQuadLines<_Getter>(getter), col_line, s.LineWeight);
+            RenderLinePrimitives<RendererLineSegments>(GetterQuadLines<_Getter>(getter), col_line, s.LineWeight);
         }
 
         // Render markers
@@ -1334,7 +1138,7 @@ template <typename _Getter> void PlotSurfaceEx(const char* label_id, const _Gett
         // Render lines
         if (getter.Count >= 2 && n.RenderLine && !ImHasFlag(spec.Flags, ImPlot3DSurfaceFlags_NoLines)) {
             const ImU32 col_line = ImGui::GetColorU32(s.LineColor);
-            RenderPrimitives<RendererLineSegments>(GetterSurfaceLines<_Getter>(getter, x_count, y_count), col_line, s.LineWeight);
+            RenderLinePrimitives<RendererLineSegments>(GetterSurfaceLines<_Getter>(getter, x_count, y_count), col_line, s.LineWeight);
         }
 
         // Render markers
@@ -1387,7 +1191,7 @@ void PlotMesh(const char* label_id, const ImPlot3DPoint* vtx, const unsigned int
         // Render lines
         if (getter.Count >= 2 && n.RenderLine && !n.IsAutoLine && !ImHasFlag(spec.Flags, ImPlot3DMeshFlags_NoLines)) {
             const ImU32 col_line = ImGui::GetColorU32(s.LineColor);
-            RenderPrimitives<RendererLineSegments>(GetterTriangleLines<GetterMeshTriangles>(getter_triangles), col_line, s.LineWeight);
+            RenderLinePrimitives<RendererLineSegments>(GetterTriangleLines<GetterMeshTriangles>(getter_triangles), col_line, s.LineWeight);
         }
 
         // Render markers


### PR DESCRIPTION
Closes #172 

This PR proposes the introduction of a Backend System for ImPlot3D. Currently, depth sorting is performed on the CPU at a per-triangle level (Z-sorting), which is computationally expensive for large datasets and fails to resolve visual artifacts when triangles intersect or overlap complexly. By supporting a dedicated OpenGL Backend, ImPlot3D can leverage the GPU's hardware depth buffer (Z-buffer) for per-pixel depth testing, ensuring perfect intersections and significantly higher performance. When no backend is initialized, ImPlot3D should fall back to CPU Z-sorting.

It is important that if the OpenGL backend is not set, ImPlot3D should fallback to rendering lines/triangles/marker just like before using the ImGui's draw list.