### PR TITLE
Feat: Per-Index Color/Size Support with ImPlot3DSpec

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -47,7 +47,7 @@ target_link_libraries(imgui PUBLIC glfw OpenGL::GL)
 FetchContent_Declare(
     implot
     GIT_REPOSITORY "https://github.com/epezent/implot"
-    GIT_TAG "v0.17"
+    GIT_TAG "feat/spec-colors"
     GIT_PROGRESS TRUE
 )
 FetchContent_MakeAvailable(implot)

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -26,7 +26,7 @@ FetchContent_MakeAvailable(glfw)
 FetchContent_Declare(
     imgui
     GIT_REPOSITORY "https://github.com/ocornut/imgui"
-    GIT_TAG "v1.92.4"
+    GIT_TAG "v1.92.7"
     GIT_PROGRESS TRUE
 )
 FetchContent_MakeAvailable(imgui)
@@ -47,7 +47,7 @@ target_link_libraries(imgui PUBLIC glfw OpenGL::GL)
 FetchContent_Declare(
     implot
     GIT_REPOSITORY "https://github.com/epezent/implot"
-    GIT_TAG "feat/spec-colors"
+    GIT_TAG "v0.17"
     GIT_PROGRESS TRUE
 )
 FetchContent_MakeAvailable(implot)

--- a/implot3d.cpp
+++ b/implot3d.cpp
@@ -48,6 +48,16 @@ Below is a change-log of API breaking changes only. If you are using one of the 
 When you are not sure about an old symbol or function name, try using the Search/Find function of your IDE to look for comments or references in all
 implot3d files. You can read releases logs https://github.com/brenocq/implot3d/releases for more details.
 
+- 2026/04/04 (0.4) - PlotMesh signature changed: the ImPlot3DPoint* overload is deprecated and will be removed in v1.0.
+                     A new overload accepting separate coordinate arrays (vtx_xs, vtx_ys, vtx_zs) was added, matching
+                     the pattern of PlotLine/PlotScatter/PlotTriangle and supporting Spec.Offset and Spec.Stride.
+                         ```cpp
+                         // Before
+                         ImPlot3D::PlotMesh("Mesh", vtx, idxs, vtx_count, idx_count);
+
+                         // After
+                         ImPlot3D::PlotMesh("Mesh", vtx_xs, vtx_ys, vtx_zs, idxs, vtx_count, idx_count);
+                         ```
 - 2026/02/03 (0.4) - ImPlotSpec was made the default and _only_ way of styling plot items. The SetNextXXXStyle functions have been removed.
                       - SetNextLineStyle has been removed, styling should be set via ImPlot3DSpec.
                           ```cpp

--- a/implot3d.cpp
+++ b/implot3d.cpp
@@ -641,7 +641,7 @@ float ComputeMaxTickLabelExtent(const ImPlot3DAxis& axis);
 
 // Spacing constants for axis tick labels and axis labels
 static const float AXIS_TICK_INNER_PAD = 5.0f;  // gap between axis edge and inner edge of tick labels
-static const float AXIS_LABEL_PAD      = 10.0f; // gap between tick label outer edge and axis label center
+static const float AXIS_LABEL_PAD = 10.0f;      // gap between tick label outer edge and axis label center
 static const float AXIS_RECT_MIN_WIDTH = 40.0f; // minimum hover rect width when labels are absent
 
 // Computes the total outward width of the hover rect for an axis
@@ -2908,7 +2908,7 @@ struct ImPlot3DStyleVarInfo {
 static const ImPlot3DStyleVarInfo GPlot3DStyleVarInfo[] = {
     // Item style
     {ImGuiDataType_Float, 1, (ImU32)offsetof(ImPlot3DStyle, LineWeight)}, // ImPlot3DStyleVar_LineWeight
-    {ImGuiDataType_S32,   1, (ImU32)offsetof(ImPlot3DStyle, Marker)},     // ImPlot3DStyleVar_Marker
+    {ImGuiDataType_S32, 1, (ImU32)offsetof(ImPlot3DStyle, Marker)},       // ImPlot3DStyleVar_Marker
     {ImGuiDataType_Float, 1, (ImU32)offsetof(ImPlot3DStyle, MarkerSize)}, // ImPlot3DStyleVar_MarkerSize
     {ImGuiDataType_Float, 1, (ImU32)offsetof(ImPlot3DStyle, FillAlpha)},  // ImPlot3DStyleVar_FillAlpha
 

--- a/implot3d.h
+++ b/implot3d.h
@@ -654,6 +654,13 @@ IMPLOT3D_TMP void PlotSurface(const char* label_id, const T* xs, const T* ys, co
 // Plots a 3D mesh given vertex positions as separate coordinate arrays and an index buffer.
 // Triangles are defined by the index buffer (every 3 indices form a triangle).
 // Spec.Offset and Spec.Stride apply to the vertex coordinate arrays only, not to the index buffer.
+// Color array semantics:
+//   - FillColors / LineColors:          idx_count entries, indexed by position in the index buffer.
+//                                       Each triangle has 3 consecutive color entries (one per corner).
+//                                       Setting all 3 to the same value gives flat per-triangle shading.
+//                                       Setting different values enables Gouraud shading (GPU-interpolated).
+//                                       To shade by vertex, map: FillColors[i] = vtx_colors[idxs[i]].
+//   - MarkerFillColors / MarkerLineColors: vtx_count entries, one per unique vertex.
 IMPLOT3D_TMP void PlotMesh(const char* label_id, const T* vtx_xs, const T* vtx_ys, const T* vtx_zs, const unsigned int* idxs, int vtx_count,
                            int idx_count, const ImPlot3DSpec& spec = ImPlot3DSpec());
 

--- a/implot3d.h
+++ b/implot3d.h
@@ -382,21 +382,21 @@ enum ImPlot3DColormap_ {
 //      ImPlot3DProp_Flags, ImPlot3DItemFlags_NoLegend | ImPlot3DLineFlags_Segments
 //    });
 struct ImPlot3DSpec {
-    ImVec4 LineColor = IMPLOT3D_AUTO_COL;         // Line color; IMPLOT3D_AUTO_COL will use next Colormap color
-    ImU32* LineColors = nullptr;                  // Per-index line colors; if nullptr, use LineColor for all
-    float LineWeight = 1.0f;                      // Line weight in pixels
-    ImVec4 FillColor = IMPLOT3D_AUTO_COL;         // Fill color (applies to shaded regions); IMPLOT3D_AUTO_COL will use next Colormap color
-    ImU32* FillColors = nullptr;                  // Per-index fill colors; if nullptr, use FillColor for all
-    float FillAlpha = IMPLOT3D_AUTO;              // Alpha multiplier (applies to FillColor, FillColors, MarkerFillColor, and MarkerFillColors)
-    ImPlot3DMarker Marker = ImPlot3DMarker_Auto;  // Marker type
-    float MarkerSize = IMPLOT3D_AUTO;             // Size of markers (radius) *in pixels*
-    float* MarkerSizes = nullptr;                 // Per-index marker sizes; if nullptr, use MarkerSize for all
-    ImVec4 MarkerLineColor = IMPLOT3D_AUTO_COL;   // Marker outline color; IMPLOT3D_AUTO_COL will use LineColor
-    ImU32* MarkerLineColors = nullptr;            // Per-index marker outline colors; if nullptr, use MarkerLineColor for all
-    ImVec4 MarkerFillColor = IMPLOT3D_AUTO_COL;   // Marker fill color; IMPLOT3D_AUTO_COL will use LineColor
-    ImU32* MarkerFillColors = nullptr;            // Per-index marker fill colors; if nullptr, use MarkerFillColor for all
-    int Offset = 0;                               // Data index offset
-    int Stride = IMPLOT3D_AUTO;                   // Data stride in bytes; IMPLOT3D_AUTO will result in sizeof(T) where T is the type passed to PlotX
+    ImVec4 LineColor = IMPLOT3D_AUTO_COL;        // Line color; IMPLOT3D_AUTO_COL will use next Colormap color
+    ImU32* LineColors = nullptr;                 // Per-index line colors; if nullptr, use LineColor for all
+    float LineWeight = 1.0f;                     // Line weight in pixels
+    ImVec4 FillColor = IMPLOT3D_AUTO_COL;        // Fill color (applies to shaded regions); IMPLOT3D_AUTO_COL will use next Colormap color
+    ImU32* FillColors = nullptr;                 // Per-index fill colors; if nullptr, use FillColor for all
+    float FillAlpha = IMPLOT3D_AUTO;             // Alpha multiplier (applies to FillColor, FillColors, MarkerFillColor, and MarkerFillColors)
+    ImPlot3DMarker Marker = ImPlot3DMarker_Auto; // Marker type
+    float MarkerSize = IMPLOT3D_AUTO;            // Size of markers (radius) *in pixels*
+    float* MarkerSizes = nullptr;                // Per-index marker sizes; if nullptr, use MarkerSize for all
+    ImVec4 MarkerLineColor = IMPLOT3D_AUTO_COL;  // Marker outline color; IMPLOT3D_AUTO_COL will use LineColor
+    ImU32* MarkerLineColors = nullptr;           // Per-index marker outline colors; if nullptr, use MarkerLineColor for all
+    ImVec4 MarkerFillColor = IMPLOT3D_AUTO_COL;  // Marker fill color; IMPLOT3D_AUTO_COL will use LineColor
+    ImU32* MarkerFillColors = nullptr;           // Per-index marker fill colors; if nullptr, use MarkerFillColor for all
+    int Offset = 0;                              // Data index offset
+    int Stride = IMPLOT3D_AUTO;                  // Data stride in bytes; IMPLOT3D_AUTO will result in sizeof(T) where T is the type passed to PlotX
     ImPlot3DItemFlags Flags =
         ImPlot3DItemFlags_None; // Optional item flags; can be composed from common ImPlot3DItemFlags and/or specialized ImPlot3DXFlags
 
@@ -439,8 +439,8 @@ struct ImPlot3DSpec {
     // Set a property from an ImU32* array (per-index colors).
     void SetProp(ImPlot3DProp prop, ImU32* v) {
         switch (prop) {
-            case ImPlot3DProp_LineColors:       LineColors       = v; return;
-            case ImPlot3DProp_FillColors:       FillColors       = v; return;
+            case ImPlot3DProp_LineColors: LineColors = v; return;
+            case ImPlot3DProp_FillColors: FillColors = v; return;
             case ImPlot3DProp_MarkerLineColors: MarkerLineColors = v; return;
             case ImPlot3DProp_MarkerFillColors: MarkerFillColors = v; return;
             default: break;
@@ -1125,8 +1125,8 @@ IMPLOT3D_DEPRECATED(IMPLOT3D_API ImVec2 GetPlotSize()); // Renamed to GetPlotRec
 
 // OBSOLETED in v0.4 -> PLANNED REMOVAL in v1.0
 // Use PlotMesh(label_id, vtx_xs, vtx_ys, vtx_zs, idx, vtx_count, idx_count, spec) instead.
-IMPLOT3D_DEPRECATED(IMPLOT3D_API void PlotMesh(const char* label_id, const ImPlot3DPoint* vtx, const unsigned int* idxs, int vtx_count,
-                                               int idx_count, const ImPlot3DSpec& spec = ImPlot3DSpec()));
+IMPLOT3D_DEPRECATED(IMPLOT3D_API void PlotMesh(const char* label_id, const ImPlot3DPoint* vtx, const unsigned int* idxs, int vtx_count, int idx_count,
+                                               const ImPlot3DSpec& spec = ImPlot3DSpec()));
 
 } // namespace ImPlot3D
 

--- a/implot3d.h
+++ b/implot3d.h
@@ -651,9 +651,11 @@ IMPLOT3D_TMP void PlotQuad(const char* label_id, const T* xs, const T* ys, const
 IMPLOT3D_TMP void PlotSurface(const char* label_id, const T* xs, const T* ys, const T* zs, int x_count, int y_count, double scale_min = 0.0,
                               double scale_max = 0.0, const ImPlot3DSpec& spec = ImPlot3DSpec());
 
-// Plots a 3D mesh given vertex positions and indices. Triangles are defined by the index buffer (every 3 indices form a triangle)
-IMPLOT3D_API void PlotMesh(const char* label_id, const ImPlot3DPoint* vtx, const unsigned int* idx, int vtx_count, int idx_count,
-                           const ImPlot3DSpec& spec = ImPlot3DSpec());
+// Plots a 3D mesh given vertex positions as separate coordinate arrays and an index buffer.
+// Triangles are defined by the index buffer (every 3 indices form a triangle).
+// Spec.Offset and Spec.Stride apply to the vertex coordinate arrays only, not to the index buffer.
+IMPLOT3D_TMP void PlotMesh(const char* label_id, const T* vtx_xs, const T* vtx_ys, const T* vtx_zs, const unsigned int* idxs, int vtx_count,
+                           int idx_count, const ImPlot3DSpec& spec = ImPlot3DSpec());
 
 // Plots a rectangular image in 3D defined by its center and two direction vectors (axes).
 // #center is the center of the rectangle in plot coordinates.
@@ -1113,6 +1115,11 @@ namespace ImPlot3D {
 // OBSOLETED in v0.3 -> PLANNED REMOVAL in v1.0
 IMPLOT3D_DEPRECATED(IMPLOT3D_API ImVec2 GetPlotPos());  // Renamed to GetPlotRectPos()
 IMPLOT3D_DEPRECATED(IMPLOT3D_API ImVec2 GetPlotSize()); // Renamed to GetPlotRectSize()
+
+// OBSOLETED in v0.4 -> PLANNED REMOVAL in v1.0
+// Use PlotMesh(label_id, vtx_xs, vtx_ys, vtx_zs, idx, vtx_count, idx_count, spec) instead.
+IMPLOT3D_DEPRECATED(IMPLOT3D_API void PlotMesh(const char* label_id, const ImPlot3DPoint* vtx, const unsigned int* idxs, int vtx_count,
+                                               int idx_count, const ImPlot3DSpec& spec = ImPlot3DSpec()));
 
 } // namespace ImPlot3D
 

--- a/implot3d.h
+++ b/implot3d.h
@@ -103,17 +103,22 @@ typedef ImTextureID ImTextureRef;
 
 // Plotting properties. These provide syntactic sugar for creating ImPlot3DSpec from (ImPlot3DProp,value) pairs
 enum ImPlot3DProp_ {
-    ImPlot3DProp_LineColor,       // Line color; IMPLOT3D_AUTO_COL will use next Colormap color
-    ImPlot3DProp_LineWeight,      // Line weight in pixels
-    ImPlot3DProp_FillColor,       // Fill color (applies to shaded regions); IMPLOT3D_AUTO_COL will use next Colormap color
-    ImPlot3DProp_FillAlpha,       // Alpha multiplier (applies to FillColor and MarkerFillColor)
-    ImPlot3DProp_Marker,          // Marker type
-    ImPlot3DProp_MarkerSize,      // Size of markers (radius) *in pixels*
-    ImPlot3DProp_MarkerLineColor, // Marker outline color; IMPLOT3D_AUTO_COL will use next LineColor
-    ImPlot3DProp_MarkerFillColor, // Marker fill color; IMPLOT3D_AUTO_COL will use LineColor
-    ImPlot3DProp_Offset,          // Data index offset
-    ImPlot3DProp_Stride,          // Data stride in bytes; IMPLOT3D_AUTO will result in sizeof(T) where T is the type passed to PlotX
-    ImPlot3DProp_Flags            // Optional item flags; can be composed from common ImPlot3DItemFlags and/or specialized ImPlot3DXFlags
+    ImPlot3DProp_LineColor,        // Line color; IMPLOT3D_AUTO_COL will use next Colormap color
+    ImPlot3DProp_LineColors,       // Array of line colors (ImU32*); if nullptr, use LineColor for all
+    ImPlot3DProp_LineWeight,       // Line weight in pixels
+    ImPlot3DProp_FillColor,        // Fill color (applies to shaded regions); IMPLOT3D_AUTO_COL will use next Colormap color
+    ImPlot3DProp_FillColors,       // Array of fill colors (ImU32*); if nullptr, use FillColor for all
+    ImPlot3DProp_FillAlpha,        // Alpha multiplier (applies to FillColor, FillColors, MarkerFillColor, and MarkerFillColors)
+    ImPlot3DProp_Marker,           // Marker type
+    ImPlot3DProp_MarkerSize,       // Size of markers (radius) *in pixels*
+    ImPlot3DProp_MarkerSizes,      // Array of marker sizes (float*); if nullptr, use MarkerSize for all
+    ImPlot3DProp_MarkerLineColor,  // Marker outline color; IMPLOT3D_AUTO_COL will use next LineColor
+    ImPlot3DProp_MarkerLineColors, // Array of marker outline colors (ImU32*); if nullptr, use MarkerLineColor for all
+    ImPlot3DProp_MarkerFillColor,  // Marker fill color; IMPLOT3D_AUTO_COL will use LineColor
+    ImPlot3DProp_MarkerFillColors, // Array of marker fill colors (ImU32*); if nullptr, use MarkerFillColor for all
+    ImPlot3DProp_Offset,           // Data index offset
+    ImPlot3DProp_Stride,           // Data stride in bytes; IMPLOT3D_AUTO will result in sizeof(T) where T is the type passed to PlotX
+    ImPlot3DProp_Flags             // Optional item flags; can be composed from common ImPlot3DItemFlags and/or specialized ImPlot3DXFlags
 };
 
 // Flags for ImPlot3D::BeginPlot()
@@ -374,16 +379,21 @@ enum ImPlot3DColormap_ {
 //      ImPlot3DProp_Flags, ImPlot3DItemFlags_NoLegend | ImPlot3DLineFlags_Segments
 //    });
 struct ImPlot3DSpec {
-    ImVec4 LineColor = IMPLOT3D_AUTO_COL;        // Line color; IMPLOT3D_AUTO_COL will use next Colormap color
-    float LineWeight = 1.0f;                     // Line weight in pixels
-    ImVec4 FillColor = IMPLOT3D_AUTO_COL;        // Fill color (applies to shaded regions); IMPLOT3D_AUTO_COL will use next Colormap color
-    float FillAlpha = IMPLOT3D_AUTO;             // Alpha multiplier (applies to FillColor and MarkerFillColor)
-    ImPlot3DMarker Marker = ImPlot3DMarker_Auto; // Marker type
-    float MarkerSize = IMPLOT3D_AUTO;            // Size of markers (radius) *in pixels*
-    ImVec4 MarkerLineColor = IMPLOT3D_AUTO_COL;  // Marker outline color; IMPLOT3D_AUTO_COL will use LineColor
-    ImVec4 MarkerFillColor = IMPLOT3D_AUTO_COL;  // Marker fill color; IMPLOT3D_AUTO_COL will use LineColor
-    int Offset = 0;                              // Data index offset
-    int Stride = IMPLOT3D_AUTO;                  // Data stride in bytes; IMPLOT3D_AUTO will result in sizeof(T) where T is the type passed to PlotX
+    ImVec4 LineColor = IMPLOT3D_AUTO_COL;         // Line color; IMPLOT3D_AUTO_COL will use next Colormap color
+    ImU32* LineColors = nullptr;                  // Per-index line colors; if nullptr, use LineColor for all
+    float LineWeight = 1.0f;                      // Line weight in pixels
+    ImVec4 FillColor = IMPLOT3D_AUTO_COL;         // Fill color (applies to shaded regions); IMPLOT3D_AUTO_COL will use next Colormap color
+    ImU32* FillColors = nullptr;                  // Per-index fill colors; if nullptr, use FillColor for all
+    float FillAlpha = IMPLOT3D_AUTO;              // Alpha multiplier (applies to FillColor, FillColors, MarkerFillColor, and MarkerFillColors)
+    ImPlot3DMarker Marker = ImPlot3DMarker_Auto;  // Marker type
+    float MarkerSize = IMPLOT3D_AUTO;             // Size of markers (radius) *in pixels*
+    float* MarkerSizes = nullptr;                 // Per-index marker sizes; if nullptr, use MarkerSize for all
+    ImVec4 MarkerLineColor = IMPLOT3D_AUTO_COL;   // Marker outline color; IMPLOT3D_AUTO_COL will use LineColor
+    ImU32* MarkerLineColors = nullptr;            // Per-index marker outline colors; if nullptr, use MarkerLineColor for all
+    ImVec4 MarkerFillColor = IMPLOT3D_AUTO_COL;   // Marker fill color; IMPLOT3D_AUTO_COL will use LineColor
+    ImU32* MarkerFillColors = nullptr;            // Per-index marker fill colors; if nullptr, use MarkerFillColor for all
+    int Offset = 0;                               // Data index offset
+    int Stride = IMPLOT3D_AUTO;                   // Data stride in bytes; IMPLOT3D_AUTO will result in sizeof(T) where T is the type passed to PlotX
     ImPlot3DItemFlags Flags =
         ImPlot3DItemFlags_None; // Optional item flags; can be composed from common ImPlot3DItemFlags and/or specialized ImPlot3DXFlags
 
@@ -421,6 +431,27 @@ struct ImPlot3DSpec {
             default: break;
         }
         IM_ASSERT(0 && "User provided an ImPlot3DProp which cannot be set from scalar value!");
+    }
+
+    // Set a property from an ImU32* array (per-index colors).
+    void SetProp(ImPlot3DProp prop, ImU32* v) {
+        switch (prop) {
+            case ImPlot3DProp_LineColors:       LineColors       = v; return;
+            case ImPlot3DProp_FillColors:       FillColors       = v; return;
+            case ImPlot3DProp_MarkerLineColors: MarkerLineColors = v; return;
+            case ImPlot3DProp_MarkerFillColors: MarkerFillColors = v; return;
+            default: break;
+        }
+        IM_ASSERT(0 && "User provided an ImPlot3DProp which cannot be set from ImU32* value!");
+    }
+
+    // Set a property from a float* array (per-index sizes).
+    void SetProp(ImPlot3DProp prop, float* v) {
+        switch (prop) {
+            case ImPlot3DProp_MarkerSizes: MarkerSizes = v; return;
+            default: break;
+        }
+        IM_ASSERT(0 && "User provided an ImPlot3DProp which cannot be set from float* value!");
     }
 
     // Set a property from an ImVec4 value.
@@ -1008,8 +1039,7 @@ struct ImPlot3DStyle {
     // Constructor
     IMPLOT3D_API ImPlot3DStyle();
     ImPlot3DStyle(const ImPlot3DStyle& other) = default;
-    ImPlot3DStyle& operator=(const ImPlot3DStyle& other) =
-  default;
+    ImPlot3DStyle& operator=(const ImPlot3DStyle& other) = default;
 };
 
 //-----------------------------------------------------------------------------
@@ -1066,11 +1096,16 @@ extern unsigned int duck_idx[DUCK_IDX_COUNT];  // Duck indices
 namespace ImPlot3D {
 
 // OBSOLETED in v0.4 (from February 2026)
-// IMPLOT_API void SetNextLineStyle(const ImVec4& col = IMPLOT_AUTO_COL, float weight = IMPLOT_AUTO); // OBSOLETED IN v0.4 // Set ImPlotSpec.LineColor/LineWeight or construct ImPlotSpec with { ImPlotSpec_LineColor, color, ImPlotSpec_LineWeight, weight }.
+// IMPLOT_API void SetNextLineStyle(const ImVec4& col = IMPLOT_AUTO_COL, float weight = IMPLOT_AUTO); // OBSOLETED IN v0.4 // Set
+// ImPlotSpec.LineColor/LineWeight or construct ImPlotSpec with { ImPlotSpec_LineColor, color, ImPlotSpec_LineWeight, weight }.
 
-// IMPLOT_API void SetNextFillStyle(const ImVec4& col = IMPLOT_AUTO_COL, float alpha_mod = IMPLOT_AUTO);// OBSOLETED IN v0.4 // Set ImPlotSpec.FillColor/FillAlpha or construct ImPlotSpec with { ImPlotSpec_FillColor, color, ImPlotSpec_FillAlpha, alpha }.
+// IMPLOT_API void SetNextFillStyle(const ImVec4& col = IMPLOT_AUTO_COL, float alpha_mod = IMPLOT_AUTO);// OBSOLETED IN v0.4 // Set
+// ImPlotSpec.FillColor/FillAlpha or construct ImPlotSpec with { ImPlotSpec_FillColor, color, ImPlotSpec_FillAlpha, alpha }.
 
-// IMPLOT_API void SetNextMarkerStyle(ImPlotMarker marker = IMPLOT_AUTO, float size = IMPLOT_AUTO, const ImVec4& fill = IMPLOT_AUTO_COL, float weight = IMPLOT_AUTO, const ImVec4& outline = IMPLOT_AUTO_COL); // OBSOLETED IN v0.4 // Set ImPlotSpec.Marker/MarkerSize/MarkerFillColor/LineWeight/MarkerLineColor or construct ImPlotSpec with { ImPlotSpec_Marker, marker, ImPlotSpec_MarkerSize, size, ImPlotSpec_MarkerFillColor, fill_color, ImPlotSpec_LineWeight, weight, ImPlotSpec_MarkerLineColor, outline }.
+// IMPLOT_API void SetNextMarkerStyle(ImPlotMarker marker = IMPLOT_AUTO, float size = IMPLOT_AUTO, const ImVec4& fill = IMPLOT_AUTO_COL, float weight
+// = IMPLOT_AUTO, const ImVec4& outline = IMPLOT_AUTO_COL); // OBSOLETED IN v0.4 // Set
+// ImPlotSpec.Marker/MarkerSize/MarkerFillColor/LineWeight/MarkerLineColor or construct ImPlotSpec with { ImPlotSpec_Marker, marker,
+// ImPlotSpec_MarkerSize, size, ImPlotSpec_MarkerFillColor, fill_color, ImPlotSpec_LineWeight, weight, ImPlotSpec_MarkerLineColor, outline }.
 
 // OBSOLETED in v0.3 -> PLANNED REMOVAL in v1.0
 IMPLOT3D_DEPRECATED(IMPLOT3D_API ImVec2 GetPlotPos());  // Renamed to GetPlotRectPos()

--- a/implot3d_demo.cpp
+++ b/implot3d_demo.cpp
@@ -31,8 +31,13 @@
 
 // Helper to wire demo markers located in code to an interactive browser (e.g. imgui_explorer)
 #if IMGUI_VERSION_NUM >= 19263
-namespace ImGui { extern IMGUI_API void DemoMarker(const char* file, int line, const char* section); };
-#define IMGUI_DEMO_MARKER(section)  do { ImGui::DemoMarker("implot3d_demo.cpp", __LINE__, section); } while (0)
+namespace ImGui {
+extern IMGUI_API void DemoMarker(const char* file, int line, const char* section);
+};
+#define IMGUI_DEMO_MARKER(section)                                                                                                                   \
+    do {                                                                                                                                             \
+        ImGui::DemoMarker("implot3d_demo.cpp", __LINE__, section);                                                                                   \
+    } while (0)
 #else
 #define IMGUI_DEMO_MARKER(section)
 #endif
@@ -352,9 +357,8 @@ void DemoSurfacePlots() {
             ys[idx] = min_val + i * step;                                             // Y values are constant along columns
             zs[idx] = ImSin(2 * t + ImSqrt((xs[idx] * xs[idx] + ys[idx] * ys[idx]))); // z = sin(2t + sqrt(x^2 + y^2))
             // Custom per-point color: R=x, G=y, B=z (each remapped from [-1,1] to [0,1])
-            custom_colors[idx] = IM_COL32((ImU8)((xs[idx] + 1) * 0.5f * 255),
-                                          (ImU8)((ys[idx] + 1) * 0.5f * 255),
-                                          (ImU8)((zs[idx] + 1) * 0.5f * 255), 255);
+            custom_colors[idx] =
+                IM_COL32((ImU8)((xs[idx] + 1) * 0.5f * 255), (ImU8)((ys[idx] + 1) * 0.5f * 255), (ImU8)((zs[idx] + 1) * 0.5f * 255), 255);
         }
     }
 
@@ -946,16 +950,10 @@ void Demo_PerIndexColors() {
         colors2[i] = ImGui::GetColorU32(color);
     }
     if (ImPlot3D::BeginPlot("Colorful Lines")) {
-        ImPlot3D::PlotLine("f(x)", xs1, ys1, zs1, 1001, {
-            ImPlot3DProp_LineColors, colors1
-        });
-        ImPlot3D::PlotLine("g(x)", xs2, ys2, zs2, 20, {
-            ImPlot3DProp_Marker,           ImPlot3DMarker_Circle,
-            ImPlot3DProp_Flags,            (int)ImPlot3DLineFlags_Segments,
-            ImPlot3DProp_LineColors,       colors2,
-            ImPlot3DProp_MarkerFillColors, colors2,
-            ImPlot3DProp_MarkerLineColors, colors2
-        });
+        ImPlot3D::PlotLine("f(x)", xs1, ys1, zs1, 1001, {ImPlot3DProp_LineColors, colors1});
+        ImPlot3D::PlotLine("g(x)", xs2, ys2, zs2, 20,
+                           {ImPlot3DProp_Marker, ImPlot3DMarker_Circle, ImPlot3DProp_Flags, (int)ImPlot3DLineFlags_Segments, ImPlot3DProp_LineColors,
+                            colors2, ImPlot3DProp_MarkerFillColors, colors2, ImPlot3DProp_MarkerLineColors, colors2});
         ImPlot3D::EndPlot();
     }
 
@@ -991,18 +989,13 @@ void Demo_PerIndexColors() {
     }
 
     if (ImPlot3D::BeginPlot("Colorful Scatter")) {
-        ImPlot3D::PlotScatter("Data 1", xs_scatter1, ys_scatter1, zs_scatter1, 100, {
-            ImPlot3DProp_MarkerFillColors, colors_scatter1_fill,
-            ImPlot3DProp_MarkerLineColors, colors_scatter1_line,
-            ImPlot3DProp_MarkerSizes,      sizes_scatter1
-        });
-        ImPlot3D::PlotScatter("Data 2", xs_scatter2, ys_scatter2, zs_scatter2, 50, {
-            ImPlot3DProp_Marker,           ImPlot3DMarker_Square,
-            ImPlot3DProp_MarkerFillColors, colors_scatter2,
-            ImPlot3DProp_MarkerLineColors, colors_scatter2,
-            ImPlot3DProp_MarkerSizes,      sizes_scatter2,
-            ImPlot3DProp_FillAlpha,        0.5f
-        });
+        ImPlot3D::PlotScatter("Data 1", xs_scatter1, ys_scatter1, zs_scatter1, 100,
+                              {ImPlot3DProp_MarkerFillColors, colors_scatter1_fill, ImPlot3DProp_MarkerLineColors, colors_scatter1_line,
+                               ImPlot3DProp_MarkerSizes, sizes_scatter1});
+        ImPlot3D::PlotScatter("Data 2", xs_scatter2, ys_scatter2, zs_scatter2, 50,
+                              {ImPlot3DProp_Marker, ImPlot3DMarker_Square, ImPlot3DProp_MarkerFillColors, colors_scatter2,
+                               ImPlot3DProp_MarkerLineColors, colors_scatter2, ImPlot3DProp_MarkerSizes, sizes_scatter2, ImPlot3DProp_FillAlpha,
+                               0.5f});
         ImPlot3D::EndPlot();
     }
 
@@ -1017,13 +1010,30 @@ void Demo_PerIndexColors() {
         float cy[4] = {-0.5f, -0.5f, 0.5f, 0.5f};
         float cz[4] = {0.0f, 0.0f, 0.0f, 0.0f};
         int v = 0;
-        auto AddVertex = [&](float x, float y, float z) { xs_tri[v] = x; ys_tri[v] = y; zs_tri[v] = z; v++; };
-        AddVertex(ax, ay, az); AddVertex(cx[0], cy[0], cz[0]); AddVertex(cx[1], cy[1], cz[1]);
-        AddVertex(ax, ay, az); AddVertex(cx[1], cy[1], cz[1]); AddVertex(cx[2], cy[2], cz[2]);
-        AddVertex(ax, ay, az); AddVertex(cx[2], cy[2], cz[2]); AddVertex(cx[3], cy[3], cz[3]);
-        AddVertex(ax, ay, az); AddVertex(cx[3], cy[3], cz[3]); AddVertex(cx[0], cy[0], cz[0]);
-        AddVertex(cx[0], cy[0], cz[0]); AddVertex(cx[1], cy[1], cz[1]); AddVertex(cx[2], cy[2], cz[2]);
-        AddVertex(cx[0], cy[0], cz[0]); AddVertex(cx[2], cy[2], cz[2]); AddVertex(cx[3], cy[3], cz[3]);
+        auto AddVertex = [&](float x, float y, float z) {
+            xs_tri[v] = x;
+            ys_tri[v] = y;
+            zs_tri[v] = z;
+            v++;
+        };
+        AddVertex(ax, ay, az);
+        AddVertex(cx[0], cy[0], cz[0]);
+        AddVertex(cx[1], cy[1], cz[1]);
+        AddVertex(ax, ay, az);
+        AddVertex(cx[1], cy[1], cz[1]);
+        AddVertex(cx[2], cy[2], cz[2]);
+        AddVertex(ax, ay, az);
+        AddVertex(cx[2], cy[2], cz[2]);
+        AddVertex(cx[3], cy[3], cz[3]);
+        AddVertex(ax, ay, az);
+        AddVertex(cx[3], cy[3], cz[3]);
+        AddVertex(cx[0], cy[0], cz[0]);
+        AddVertex(cx[0], cy[0], cz[0]);
+        AddVertex(cx[1], cy[1], cz[1]);
+        AddVertex(cx[2], cy[2], cz[2]);
+        AddVertex(cx[0], cy[0], cz[0]);
+        AddVertex(cx[2], cy[2], cz[2]);
+        AddVertex(cx[3], cy[3], cz[3]);
         // Hot colormap sampled by z: bottom (z=0) is cold, apex (z=1) is hot
         for (int i = 0; i < 18; ++i) {
             ImVec4 color = ImPlot3D::SampleColormap(0.5f * zs_tri[i], ImPlot3DColormap_Hot);
@@ -1032,10 +1042,7 @@ void Demo_PerIndexColors() {
     }
     if (ImPlot3D::BeginPlot("Colorful Triangles")) {
         ImPlot3D::SetupAxesLimits(-1, 1, -1, 1, -0.5, 1.5);
-        ImPlot3D::PlotTriangle("Pyramid", xs_tri, ys_tri, zs_tri, 18, {
-            ImPlot3DProp_FillColors, colors_tri,
-            ImPlot3DProp_FillAlpha,  0.8f
-        });
+        ImPlot3D::PlotTriangle("Pyramid", xs_tri, ys_tri, zs_tri, 18, {ImPlot3DProp_FillColors, colors_tri, ImPlot3DProp_FillAlpha, 0.8f});
         ImPlot3D::EndPlot();
     }
 
@@ -1057,10 +1064,7 @@ void Demo_PerIndexColors() {
     }
     if (ImPlot3D::BeginPlot("Colorful Quads")) {
         ImPlot3D::SetupAxesLimits(-0.5, 1.5, -0.5, 1.5, -0.5, 1.5);
-        ImPlot3D::PlotQuad("Cube", xs_quad, ys_quad, zs_quad, 24, {
-            ImPlot3DProp_FillColors, colors_quad,
-            ImPlot3DProp_FillAlpha,  0.8f
-        });
+        ImPlot3D::PlotQuad("Cube", xs_quad, ys_quad, zs_quad, 24, {ImPlot3DProp_FillColors, colors_quad, ImPlot3DProp_FillAlpha, 0.8f});
         ImPlot3D::EndPlot();
     }
 
@@ -1076,9 +1080,7 @@ void Demo_PerIndexColors() {
         };
         auto sub3 = [](Vec3 a, Vec3 b) -> Vec3 { return {a.x - b.x, a.y - b.y, a.z - b.z}; };
         auto add3 = [](Vec3 a, Vec3 b) -> Vec3 { return {a.x + b.x, a.y + b.y, a.z + b.z}; };
-        auto cross3 = [](Vec3 a, Vec3 b) -> Vec3 {
-            return {a.y * b.z - a.z * b.y, a.z * b.x - a.x * b.z, a.x * b.y - a.y * b.x};
-        };
+        auto cross3 = [](Vec3 a, Vec3 b) -> Vec3 { return {a.y * b.z - a.z * b.y, a.z * b.x - a.x * b.z, a.x * b.y - a.y * b.x}; };
         auto dot3 = [](Vec3 a, Vec3 b) { return a.x * b.x + a.y * b.y + a.z * b.z; };
         auto norm3 = [&dot3](Vec3 a) -> Vec3 {
             float len = sqrtf(dot3(a, a));
@@ -1101,9 +1103,9 @@ void Demo_PerIndexColors() {
 
         // Lighting: yellow duck, warm point light, soft ambient
         Vec3 light_pos = {2.0f, 2.0f, 3.0f};
-        Vec3 duck_col = {1.0f, 0.85f, 0.1f};   // yellow
-        Vec3 light_col = {1.0f, 0.95f, 0.8f};  // warm white
-        Vec3 ambient = {0.15f, 0.12f, 0.03f};  // dim warm ambient
+        Vec3 duck_col = {1.0f, 0.85f, 0.1f};  // yellow
+        Vec3 light_col = {1.0f, 0.95f, 0.8f}; // warm white
+        Vec3 ambient = {0.15f, 0.12f, 0.03f}; // dim warm ambient
 
         ImU32 vtx_colors[DUCK_VTX_COUNT];
         for (int v = 0; v < DUCK_VTX_COUNT; v++) {
@@ -1124,11 +1126,9 @@ void Demo_PerIndexColors() {
     }
     if (ImPlot3D::BeginPlot("Gouraud Duck")) {
         ImPlot3D::SetupAxesLimits(-1, 1, -1, 1, -1, 1);
-        ImPlot3D::PlotMesh("Duck", &duck_vtx[0].x, &duck_vtx[0].y, &duck_vtx[0].z, duck_idx, DUCK_VTX_COUNT, DUCK_IDX_COUNT, {
-            ImPlot3DProp_Stride,     (int)sizeof(ImPlot3DPoint),
-            ImPlot3DProp_FillColors, duck_fill_colors,
-            ImPlot3DProp_Flags,      (int)ImPlot3DMeshFlags_NoLines
-        });
+        ImPlot3D::PlotMesh("Duck", &duck_vtx[0].x, &duck_vtx[0].y, &duck_vtx[0].z, duck_idx, DUCK_VTX_COUNT, DUCK_IDX_COUNT,
+                           {ImPlot3DProp_Stride, (int)sizeof(ImPlot3DPoint), ImPlot3DProp_FillColors, duck_fill_colors, ImPlot3DProp_Flags,
+                            (int)ImPlot3DMeshFlags_NoLines});
         ImPlot3D::EndPlot();
     }
 }

--- a/implot3d_demo.cpp
+++ b/implot3d_demo.cpp
@@ -335,6 +335,7 @@ void DemoSurfacePlots() {
     IMGUI_DEMO_MARKER("Plots/Surface Plots");
     constexpr int N = 20;
     static float xs[N * N], ys[N * N], zs[N * N];
+    static ImU32 custom_colors[N * N];
     static float t = 0.0f;
     t += ImGui::GetIO().DeltaTime;
 
@@ -350,6 +351,10 @@ void DemoSurfacePlots() {
             xs[idx] = min_val + j * step;                                             // X values are constant along rows
             ys[idx] = min_val + i * step;                                             // Y values are constant along columns
             zs[idx] = ImSin(2 * t + ImSqrt((xs[idx] * xs[idx] + ys[idx] * ys[idx]))); // z = sin(2t + sqrt(x^2 + y^2))
+            // Custom per-point color: R=x, G=y, B=z (each remapped from [-1,1] to [0,1])
+            custom_colors[idx] = IM_COL32((ImU8)((xs[idx] + 1) * 0.5f * 255),
+                                          (ImU8)((ys[idx] + 1) * 0.5f * 255),
+                                          (ImU8)((zs[idx] + 1) * 0.5f * 255), 255);
         }
     }
 
@@ -375,13 +380,21 @@ void DemoSurfacePlots() {
             ImGui::SameLine();
             ImGui::Combo("##SurfaceColormap", &sel_colormap, colormaps, IM_ARRAYSIZE(colormaps));
         }
+
+        // Custom per-point colors
+        ImGui::RadioButton("Custom Per-Point", &selected_fill, 2);
+        if (selected_fill == 2)
+            ImGui::SameLine(), ImGui::TextDisabled("R=x, G=y, B=z");
+
         ImGui::Unindent();
     }
 
-    // Choose range
+    // Choose range (only applies to Colormap mode)
     static bool custom_range = false;
     static float range_min = -1.0f;
     static float range_max = 1.0f;
+    if (selected_fill != 1)
+        ImGui::BeginDisabled();
     ImGui::Checkbox("Custom range", &custom_range);
     {
         ImGui::Indent();
@@ -395,6 +408,8 @@ void DemoSurfacePlots() {
 
         ImGui::Unindent();
     }
+    if (selected_fill != 1)
+        ImGui::EndDisabled();
 
     // Select flags
     static ImPlot3DSurfaceFlags flags = ImPlot3DSurfaceFlags_NoMarkers;
@@ -415,6 +430,8 @@ void DemoSurfacePlots() {
         spec.LineColor = ImPlot3D::GetColormapColor(1);
         if (selected_fill == 0)
             spec.FillColor = solid_color;
+        else if (selected_fill == 2)
+            spec.FillColors = custom_colors;
 
         // Plot the surface
         if (custom_range)

--- a/implot3d_demo.cpp
+++ b/implot3d_demo.cpp
@@ -164,57 +164,6 @@ void DemoScatterPlots() {
     }
 }
 
-void Demo_PerIndexColors() {
-    IMGUI_DEMO_MARKER("Plots/Per-Index Colors");
-
-    // Colorful Scatter
-    srand(0);
-    static float xs_scatter1[100], ys_scatter1[100], zs_scatter1[100];
-    static ImU32 colors_scatter1_fill[100], colors_scatter1_line[100];
-    static float sizes_scatter1[100];
-    for (int i = 0; i < 100; ++i) {
-        xs_scatter1[i] = i * 0.01f;
-        ys_scatter1[i] = xs_scatter1[i] + 0.1f * ((float)rand() / (float)RAND_MAX);
-        zs_scatter1[i] = xs_scatter1[i] + 0.1f * ((float)rand() / (float)RAND_MAX);
-        // Rainbow hue colors
-        float hue = i / 99.0f;
-        colors_scatter1_fill[i] = ImColor::HSV(hue, 0.8f, 0.9f);
-        colors_scatter1_line[i] = ImColor::HSV(hue, 0.9f, 0.7f);
-        // Random sizes between 2 and 6
-        sizes_scatter1[i] = 2.0f + 4.0f * ((float)rand() / (float)RAND_MAX);
-    }
-    static float xs_scatter2[50], ys_scatter2[50], zs_scatter2[50];
-    static ImU32 colors_scatter2[50];
-    static float sizes_scatter2[50];
-    for (int i = 0; i < 50; ++i) {
-        xs_scatter2[i] = 0.25f + 0.2f * ((float)rand() / (float)RAND_MAX);
-        ys_scatter2[i] = 0.50f + 0.2f * ((float)rand() / (float)RAND_MAX);
-        zs_scatter2[i] = 0.75f + 0.2f * ((float)rand() / (float)RAND_MAX);
-        // Colormap colors (Viridis)
-        float t = i / 49.0f;
-        ImVec4 color = ImPlot3D::SampleColormap(t, ImPlot3DColormap_Viridis);
-        colors_scatter2[i] = ImGui::GetColorU32(color);
-        // Random sizes between 2 and 6
-        sizes_scatter2[i] = 2.0f + 4.0f * ((float)rand() / (float)RAND_MAX);
-    }
-
-    if (ImPlot3D::BeginPlot("Colorful Scatter")) {
-        ImPlot3D::PlotScatter("Data 1", xs_scatter1, ys_scatter1, zs_scatter1, 100, {
-            ImPlot3DProp_MarkerFillColors, colors_scatter1_fill,
-            ImPlot3DProp_MarkerLineColors, colors_scatter1_line,
-            ImPlot3DProp_MarkerSizes,      sizes_scatter1
-        });
-        ImPlot3D::PlotScatter("Data 2", xs_scatter2, ys_scatter2, zs_scatter2, 50, {
-            ImPlot3DProp_Marker,           ImPlot3DMarker_Square,
-            ImPlot3DProp_MarkerFillColors, colors_scatter2,
-            ImPlot3DProp_MarkerLineColors, colors_scatter2,
-            ImPlot3DProp_MarkerSizes,      sizes_scatter2,
-            ImPlot3DProp_FillAlpha,        0.5f
-        });
-        ImPlot3D::EndPlot();
-    }
-}
-
 void DemoTrianglePlots() {
     IMGUI_DEMO_MARKER("Plots/Triangle Plots");
     // Pyramid coordinates
@@ -953,6 +902,93 @@ void DemoNaNValues() {
     }
 }
 
+void Demo_PerIndexColors() {
+    IMGUI_DEMO_MARKER("Plots/Per-Index Colors");
+
+    // Colorful Lines
+    static float xs1[1001], ys1[1001], zs1[1001];
+    static ImU32 colors1[1001];
+    for (int i = 0; i < 1001; ++i) {
+        xs1[i] = i * 0.001f;
+        ys1[i] = 0.5f + 0.5f * sinf(50 * (xs1[i] + (float)ImGui::GetTime() / 10));
+        zs1[i] = 0.5f + 0.5f * cosf(50 * (xs1[i] + (float)ImGui::GetTime() / 10));
+        // Rainbow colors
+        float hue = (float)i / 1000.0f;
+        colors1[i] = ImColor::HSV(hue, 0.8f, 0.9f);
+    }
+    static float xs2[20], ys2[20], zs2[20];
+    static ImU32 colors2[20];
+    for (int i = 0; i < 20; ++i) {
+        xs2[i] = i * 1 / 19.0f;
+        ys2[i] = xs2[i] * xs2[i];
+        zs2[i] = xs2[i] * ys2[i];
+        // Colormap colors (Viridis)
+        float t = i / 19.0f;
+        ImVec4 color = ImPlot3D::SampleColormap(t, ImPlot3DColormap_Viridis);
+        colors2[i] = ImGui::GetColorU32(color);
+    }
+    if (ImPlot3D::BeginPlot("Colorful Lines")) {
+        ImPlot3D::PlotLine("f(x)", xs1, ys1, zs1, 1001, {
+            ImPlot3DProp_LineColors, colors1
+        });
+        ImPlot3D::PlotLine("g(x)", xs2, ys2, zs2, 20, {
+            ImPlot3DProp_Marker,           ImPlot3DMarker_Circle,
+            ImPlot3DProp_Flags,            (int)ImPlot3DLineFlags_Segments,
+            ImPlot3DProp_LineColors,       colors2,
+            ImPlot3DProp_MarkerFillColors, colors2,
+            ImPlot3DProp_MarkerLineColors, colors2
+        });
+        ImPlot3D::EndPlot();
+    }
+
+    // Colorful Scatter
+    srand(0);
+    static float xs_scatter1[100], ys_scatter1[100], zs_scatter1[100];
+    static ImU32 colors_scatter1_fill[100], colors_scatter1_line[100];
+    static float sizes_scatter1[100];
+    for (int i = 0; i < 100; ++i) {
+        xs_scatter1[i] = i * 0.01f;
+        ys_scatter1[i] = xs_scatter1[i] + 0.1f * ((float)rand() / (float)RAND_MAX);
+        zs_scatter1[i] = xs_scatter1[i] + 0.1f * ((float)rand() / (float)RAND_MAX);
+        // Rainbow hue colors
+        float hue = i / 99.0f;
+        colors_scatter1_fill[i] = ImColor::HSV(hue, 0.8f, 0.9f);
+        colors_scatter1_line[i] = ImColor::HSV(hue, 0.9f, 0.7f);
+        // Random sizes between 2 and 6
+        sizes_scatter1[i] = 2.0f + 4.0f * ((float)rand() / (float)RAND_MAX);
+    }
+    static float xs_scatter2[50], ys_scatter2[50], zs_scatter2[50];
+    static ImU32 colors_scatter2[50];
+    static float sizes_scatter2[50];
+    for (int i = 0; i < 50; ++i) {
+        xs_scatter2[i] = 0.25f + 0.2f * ((float)rand() / (float)RAND_MAX);
+        ys_scatter2[i] = 0.50f + 0.2f * ((float)rand() / (float)RAND_MAX);
+        zs_scatter2[i] = 0.75f + 0.2f * ((float)rand() / (float)RAND_MAX);
+        // Colormap colors (Viridis)
+        float t = i / 49.0f;
+        ImVec4 color = ImPlot3D::SampleColormap(t, ImPlot3DColormap_Viridis);
+        colors_scatter2[i] = ImGui::GetColorU32(color);
+        // Random sizes between 2 and 6
+        sizes_scatter2[i] = 2.0f + 4.0f * ((float)rand() / (float)RAND_MAX);
+    }
+
+    if (ImPlot3D::BeginPlot("Colorful Scatter")) {
+        ImPlot3D::PlotScatter("Data 1", xs_scatter1, ys_scatter1, zs_scatter1, 100, {
+            ImPlot3DProp_MarkerFillColors, colors_scatter1_fill,
+            ImPlot3DProp_MarkerLineColors, colors_scatter1_line,
+            ImPlot3DProp_MarkerSizes,      sizes_scatter1
+        });
+        ImPlot3D::PlotScatter("Data 2", xs_scatter2, ys_scatter2, zs_scatter2, 50, {
+            ImPlot3DProp_Marker,           ImPlot3DMarker_Square,
+            ImPlot3DProp_MarkerFillColors, colors_scatter2,
+            ImPlot3DProp_MarkerLineColors, colors_scatter2,
+            ImPlot3DProp_MarkerSizes,      sizes_scatter2,
+            ImPlot3DProp_FillAlpha,        0.5f
+        });
+        ImPlot3D::EndPlot();
+    }
+}
+
 //-----------------------------------------------------------------------------
 // [SECTION] Axes
 //-----------------------------------------------------------------------------
@@ -1682,7 +1718,6 @@ void ShowAllDemos() {
             ImGui::SeparatorText("Plot Types");
             DemoHeader("Line Plots", DemoLinePlots);
             DemoHeader("Scatter Plots", DemoScatterPlots);
-            DemoHeader("Per-Index Colors", Demo_PerIndexColors);
             DemoHeader("Triangle Plots", DemoTrianglePlots);
             DemoHeader("Quad Plots", DemoQuadPlots);
             DemoHeader("Surface Plots", DemoSurfacePlots);
@@ -1697,6 +1732,7 @@ void ShowAllDemos() {
             DemoHeader("Legend Options", DemoLegendOptions);
             DemoHeader("Markers and Text", DemoMarkersAndText);
             DemoHeader("NaN Values", DemoNaNValues);
+            DemoHeader("Per-Index Colors", Demo_PerIndexColors);
             ImGui::EndTabItem();
         }
         if (ImGui::BeginTabItem("Axes")) {

--- a/implot3d_demo.cpp
+++ b/implot3d_demo.cpp
@@ -1631,6 +1631,18 @@ void DemoCustomPerPointStyle() {
         initialized = true;
     }
 
+    // Precompute per-point colors and flat XYZ arrays for each torus
+    static float xs[3][400], ys[3][400], zs[3][400];
+    ImU32 point_colors[3][400];
+    for (int torus = 0; torus < 3; torus++) {
+        for (int i = 0; i < 400; i++) {
+            xs[torus][i] = torus_data[torus][i][0];
+            ys[torus][i] = torus_data[torus][i][1];
+            zs[torus][i] = torus_data[torus][i][2];
+            point_colors[torus][i] = ImGui::ColorConvertFloat4ToU32(ImPlot3D::SampleColormap(torus_data[torus][i][3], cmap));
+        }
+    }
+
     if (ImPlot3D::BeginPlot("##PerPointStyle", ImVec2(-1, 0))) {
         ImPlot3D::SetupAxes("X", "Y", "Z");
         ImPlot3D::SetupAxesLimits(-1, 1, -1, 1, -0.5, 1.5);
@@ -1647,21 +1659,14 @@ void DemoCustomPerPointStyle() {
         spec.MarkerSize = marker_size;
 
         for (int torus = 0; torus < 3; torus++) {
-            const int point_count = 400;
-            for (int i = 0; i < point_count; i++) {
-                float x = torus_data[torus][i][0];
-                float y = torus_data[torus][i][1];
-                float z = torus_data[torus][i][2];
-                float t = torus_data[torus][i][3];
-
-                // Sample colormap and set marker style
-                ImVec4 color = ImPlot3D::SampleColormap(t, cmap);
-                spec.FillColor = color;
-                spec.LineColor = color;
-                ImPlot3D::PlotScatter(labels[torus], &x, &y, &z, 1, spec);
-            }
+            spec.MarkerFillColors = point_colors[torus];
+            spec.MarkerLineColors = point_colors[torus];
+            ImPlot3D::PlotScatter(labels[torus], xs[torus], ys[torus], zs[torus], 400, spec);
             // Override legend color with PlotDummy
-            spec.LineColor = legend_colors[torus];
+            spec.MarkerFillColors = nullptr;
+            spec.MarkerLineColors = nullptr;
+            spec.MarkerFillColor = legend_colors[torus];
+            spec.MarkerLineColor = legend_colors[torus];
             ImPlot3D::PlotDummy(labels[torus], spec);
         }
 

--- a/implot3d_demo.cpp
+++ b/implot3d_demo.cpp
@@ -164,6 +164,57 @@ void DemoScatterPlots() {
     }
 }
 
+void Demo_PerIndexColors() {
+    IMGUI_DEMO_MARKER("Plots/Per-Index Colors");
+
+    // Colorful Scatter
+    srand(0);
+    static float xs_scatter1[100], ys_scatter1[100], zs_scatter1[100];
+    static ImU32 colors_scatter1_fill[100], colors_scatter1_line[100];
+    static float sizes_scatter1[100];
+    for (int i = 0; i < 100; ++i) {
+        xs_scatter1[i] = i * 0.01f;
+        ys_scatter1[i] = xs_scatter1[i] + 0.1f * ((float)rand() / (float)RAND_MAX);
+        zs_scatter1[i] = xs_scatter1[i] + 0.1f * ((float)rand() / (float)RAND_MAX);
+        // Rainbow hue colors
+        float hue = i / 99.0f;
+        colors_scatter1_fill[i] = ImColor::HSV(hue, 0.8f, 0.9f);
+        colors_scatter1_line[i] = ImColor::HSV(hue, 0.9f, 0.7f);
+        // Random sizes between 2 and 6
+        sizes_scatter1[i] = 2.0f + 4.0f * ((float)rand() / (float)RAND_MAX);
+    }
+    static float xs_scatter2[50], ys_scatter2[50], zs_scatter2[50];
+    static ImU32 colors_scatter2[50];
+    static float sizes_scatter2[50];
+    for (int i = 0; i < 50; ++i) {
+        xs_scatter2[i] = 0.25f + 0.2f * ((float)rand() / (float)RAND_MAX);
+        ys_scatter2[i] = 0.50f + 0.2f * ((float)rand() / (float)RAND_MAX);
+        zs_scatter2[i] = 0.75f + 0.2f * ((float)rand() / (float)RAND_MAX);
+        // Colormap colors (Viridis)
+        float t = i / 49.0f;
+        ImVec4 color = ImPlot3D::SampleColormap(t, ImPlot3DColormap_Viridis);
+        colors_scatter2[i] = ImGui::GetColorU32(color);
+        // Random sizes between 2 and 6
+        sizes_scatter2[i] = 2.0f + 4.0f * ((float)rand() / (float)RAND_MAX);
+    }
+
+    if (ImPlot3D::BeginPlot("Colorful Scatter")) {
+        ImPlot3D::PlotScatter("Data 1", xs_scatter1, ys_scatter1, zs_scatter1, 100, {
+            ImPlot3DProp_MarkerFillColors, colors_scatter1_fill,
+            ImPlot3DProp_MarkerLineColors, colors_scatter1_line,
+            ImPlot3DProp_MarkerSizes,      sizes_scatter1
+        });
+        ImPlot3D::PlotScatter("Data 2", xs_scatter2, ys_scatter2, zs_scatter2, 50, {
+            ImPlot3DProp_Marker,           ImPlot3DMarker_Square,
+            ImPlot3DProp_MarkerFillColors, colors_scatter2,
+            ImPlot3DProp_MarkerLineColors, colors_scatter2,
+            ImPlot3DProp_MarkerSizes,      sizes_scatter2,
+            ImPlot3DProp_FillAlpha,        0.5f
+        });
+        ImPlot3D::EndPlot();
+    }
+}
+
 void DemoTrianglePlots() {
     IMGUI_DEMO_MARKER("Plots/Triangle Plots");
     // Pyramid coordinates
@@ -1631,6 +1682,7 @@ void ShowAllDemos() {
             ImGui::SeparatorText("Plot Types");
             DemoHeader("Line Plots", DemoLinePlots);
             DemoHeader("Scatter Plots", DemoScatterPlots);
+            DemoHeader("Per-Index Colors", Demo_PerIndexColors);
             DemoHeader("Triangle Plots", DemoTrianglePlots);
             DemoHeader("Quad Plots", DemoQuadPlots);
             DemoHeader("Surface Plots", DemoSurfacePlots);

--- a/implot3d_demo.cpp
+++ b/implot3d_demo.cpp
@@ -987,6 +987,64 @@ void Demo_PerIndexColors() {
         });
         ImPlot3D::EndPlot();
     }
+
+    // Colorful Triangles (pyramid with per-vertex fill colors)
+    static float xs_tri[18], ys_tri[18], zs_tri[18];
+    static ImU32 colors_tri[18];
+    {
+        // Apex
+        float ax = 0.0f, ay = 0.0f, az = 1.0f;
+        // Square base corners
+        float cx[4] = {-0.5f, 0.5f, 0.5f, -0.5f};
+        float cy[4] = {-0.5f, -0.5f, 0.5f, 0.5f};
+        float cz[4] = {0.0f, 0.0f, 0.0f, 0.0f};
+        int v = 0;
+        auto AddVertex = [&](float x, float y, float z) { xs_tri[v] = x; ys_tri[v] = y; zs_tri[v] = z; v++; };
+        AddVertex(ax, ay, az); AddVertex(cx[0], cy[0], cz[0]); AddVertex(cx[1], cy[1], cz[1]);
+        AddVertex(ax, ay, az); AddVertex(cx[1], cy[1], cz[1]); AddVertex(cx[2], cy[2], cz[2]);
+        AddVertex(ax, ay, az); AddVertex(cx[2], cy[2], cz[2]); AddVertex(cx[3], cy[3], cz[3]);
+        AddVertex(ax, ay, az); AddVertex(cx[3], cy[3], cz[3]); AddVertex(cx[0], cy[0], cz[0]);
+        AddVertex(cx[0], cy[0], cz[0]); AddVertex(cx[1], cy[1], cz[1]); AddVertex(cx[2], cy[2], cz[2]);
+        AddVertex(cx[0], cy[0], cz[0]); AddVertex(cx[2], cy[2], cz[2]); AddVertex(cx[3], cy[3], cz[3]);
+        // Hot colormap sampled by z: bottom (z=0) is cold, apex (z=1) is hot
+        for (int i = 0; i < 18; ++i) {
+            ImVec4 color = ImPlot3D::SampleColormap(0.5f * zs_tri[i], ImPlot3DColormap_Hot);
+            colors_tri[i] = ImGui::GetColorU32(color);
+        }
+    }
+    if (ImPlot3D::BeginPlot("Colorful Triangles")) {
+        ImPlot3D::SetupAxesLimits(-1, 1, -1, 1, -0.5, 1.5);
+        ImPlot3D::PlotTriangle("Pyramid", xs_tri, ys_tri, zs_tri, 18, {
+            ImPlot3DProp_FillColors, colors_tri,
+            ImPlot3DProp_FillAlpha,  0.8f
+        });
+        ImPlot3D::EndPlot();
+    }
+
+    // Colorful Quads (cube [0,1]^3 with per-vertex RGB colors: R=x, G=y, B=z)
+    static float xs_quad[24], ys_quad[24], zs_quad[24];
+    static ImU32 colors_quad[24];
+    {
+        // clang-format off
+        xs_quad[0]=1; ys_quad[0]=0; zs_quad[0]=0;  xs_quad[1]=1; ys_quad[1]=1; zs_quad[1]=0;  xs_quad[2]=1; ys_quad[2]=1; zs_quad[2]=1;  xs_quad[3]=1; ys_quad[3]=0; zs_quad[3]=1;
+        xs_quad[4]=0; ys_quad[4]=0; zs_quad[4]=0;  xs_quad[5]=0; ys_quad[5]=1; zs_quad[5]=0;  xs_quad[6]=0; ys_quad[6]=1; zs_quad[6]=1;  xs_quad[7]=0; ys_quad[7]=0; zs_quad[7]=1;
+        xs_quad[8]=0; ys_quad[8]=1; zs_quad[8]=0;  xs_quad[9]=1; ys_quad[9]=1; zs_quad[9]=0;  xs_quad[10]=1; ys_quad[10]=1; zs_quad[10]=1;  xs_quad[11]=0; ys_quad[11]=1; zs_quad[11]=1;
+        xs_quad[12]=0; ys_quad[12]=0; zs_quad[12]=0;  xs_quad[13]=1; ys_quad[13]=0; zs_quad[13]=0;  xs_quad[14]=1; ys_quad[14]=0; zs_quad[14]=1;  xs_quad[15]=0; ys_quad[15]=0; zs_quad[15]=1;
+        xs_quad[16]=0; ys_quad[16]=0; zs_quad[16]=1;  xs_quad[17]=1; ys_quad[17]=0; zs_quad[17]=1;  xs_quad[18]=1; ys_quad[18]=1; zs_quad[18]=1;  xs_quad[19]=0; ys_quad[19]=1; zs_quad[19]=1;
+        xs_quad[20]=0; ys_quad[20]=0; zs_quad[20]=0;  xs_quad[21]=1; ys_quad[21]=0; zs_quad[21]=0;  xs_quad[22]=1; ys_quad[22]=1; zs_quad[22]=0;  xs_quad[23]=0; ys_quad[23]=1; zs_quad[23]=0;
+        // clang-format on
+        // Color = (R=x, G=y, B=z) per vertex
+        for (int i = 0; i < 24; ++i)
+            colors_quad[i] = IM_COL32((ImU8)(xs_quad[i] * 255), (ImU8)(ys_quad[i] * 255), (ImU8)(zs_quad[i] * 255), 255);
+    }
+    if (ImPlot3D::BeginPlot("Colorful Quads")) {
+        ImPlot3D::SetupAxesLimits(-0.5, 1.5, -0.5, 1.5, -0.5, 1.5);
+        ImPlot3D::PlotQuad("Cube", xs_quad, ys_quad, zs_quad, 24, {
+            ImPlot3DProp_FillColors, colors_quad,
+            ImPlot3DProp_FillAlpha,  0.8f
+        });
+        ImPlot3D::EndPlot();
+    }
 }
 
 //-----------------------------------------------------------------------------

--- a/implot3d_demo.cpp
+++ b/implot3d_demo.cpp
@@ -474,6 +474,7 @@ void DemoMeshPlots() {
 
         ImPlot3DSpec spec;
         spec.Flags = flags;
+        spec.Stride = (int)sizeof(ImPlot3DPoint);
         // Set fill style
         spec.FillColor = fill_color;
         // Set line style
@@ -486,11 +487,11 @@ void DemoMeshPlots() {
 
         // Plot mesh
         if (mesh_id == 0)
-            ImPlot3D::PlotMesh("Duck", duck_vtx, duck_idx, DUCK_VTX_COUNT, DUCK_IDX_COUNT, spec);
+            ImPlot3D::PlotMesh("Duck", &duck_vtx[0].x, &duck_vtx[0].y, &duck_vtx[0].z, duck_idx, DUCK_VTX_COUNT, DUCK_IDX_COUNT, spec);
         else if (mesh_id == 1)
-            ImPlot3D::PlotMesh("Sphere", sphere_vtx, sphere_idx, SPHERE_VTX_COUNT, SPHERE_IDX_COUNT, spec);
+            ImPlot3D::PlotMesh("Sphere", &sphere_vtx[0].x, &sphere_vtx[0].y, &sphere_vtx[0].z, sphere_idx, SPHERE_VTX_COUNT, SPHERE_IDX_COUNT, spec);
         else if (mesh_id == 2)
-            ImPlot3D::PlotMesh("Cube", cube_vtx, cube_idx, CUBE_VTX_COUNT, CUBE_IDX_COUNT, spec);
+            ImPlot3D::PlotMesh("Cube", &cube_vtx[0].x, &cube_vtx[0].y, &cube_vtx[0].z, cube_idx, CUBE_VTX_COUNT, CUBE_IDX_COUNT, spec);
 
         ImPlot3D::EndPlot();
     }

--- a/implot3d_demo.cpp
+++ b/implot3d_demo.cpp
@@ -1063,6 +1063,74 @@ void Demo_PerIndexColors() {
         });
         ImPlot3D::EndPlot();
     }
+
+    // Gouraud-shaded Duck (yellow duck lit by a point light with ambient)
+    // Per-vertex normals are computed once, then mapped to index-buffer slots so the GPU
+    // interpolates colors across each triangle (Gouraud shading).
+    static ImU32 duck_fill_colors[DUCK_IDX_COUNT];
+    static bool duck_colors_built = false;
+    if (!duck_colors_built) {
+        // Accumulate area-weighted face normals into each vertex
+        struct Vec3 {
+            float x, y, z;
+        };
+        auto sub3 = [](Vec3 a, Vec3 b) -> Vec3 { return {a.x - b.x, a.y - b.y, a.z - b.z}; };
+        auto add3 = [](Vec3 a, Vec3 b) -> Vec3 { return {a.x + b.x, a.y + b.y, a.z + b.z}; };
+        auto cross3 = [](Vec3 a, Vec3 b) -> Vec3 {
+            return {a.y * b.z - a.z * b.y, a.z * b.x - a.x * b.z, a.x * b.y - a.y * b.x};
+        };
+        auto dot3 = [](Vec3 a, Vec3 b) { return a.x * b.x + a.y * b.y + a.z * b.z; };
+        auto norm3 = [&dot3](Vec3 a) -> Vec3 {
+            float len = sqrtf(dot3(a, a));
+            return len > 1e-8f ? Vec3{a.x / len, a.y / len, a.z / len} : Vec3{0, 0, 1};
+        };
+
+        Vec3 vtx_normals[DUCK_VTX_COUNT] = {};
+        for (int i = 0; i < DUCK_IDX_COUNT; i += 3) {
+            unsigned int i0 = duck_idx[i], i1 = duck_idx[i + 1], i2 = duck_idx[i + 2];
+            Vec3 p0 = {(float)duck_vtx[i0].x, (float)duck_vtx[i0].y, (float)duck_vtx[i0].z};
+            Vec3 p1 = {(float)duck_vtx[i1].x, (float)duck_vtx[i1].y, (float)duck_vtx[i1].z};
+            Vec3 p2 = {(float)duck_vtx[i2].x, (float)duck_vtx[i2].y, (float)duck_vtx[i2].z};
+            Vec3 fn = cross3(sub3(p1, p0), sub3(p2, p0)); // area-weighted face normal
+            vtx_normals[i0] = add3(vtx_normals[i0], fn);
+            vtx_normals[i1] = add3(vtx_normals[i1], fn);
+            vtx_normals[i2] = add3(vtx_normals[i2], fn);
+        }
+        for (int v = 0; v < DUCK_VTX_COUNT; v++)
+            vtx_normals[v] = norm3(vtx_normals[v]);
+
+        // Lighting: yellow duck, warm point light, soft ambient
+        Vec3 light_pos = {2.0f, 2.0f, 3.0f};
+        Vec3 duck_col = {1.0f, 0.85f, 0.1f};   // yellow
+        Vec3 light_col = {1.0f, 0.95f, 0.8f};  // warm white
+        Vec3 ambient = {0.15f, 0.12f, 0.03f};  // dim warm ambient
+
+        ImU32 vtx_colors[DUCK_VTX_COUNT];
+        for (int v = 0; v < DUCK_VTX_COUNT; v++) {
+            Vec3 pos = {(float)duck_vtx[v].x, (float)duck_vtx[v].y, (float)duck_vtx[v].z};
+            Vec3 to_light = norm3(sub3(light_pos, pos));
+            float diff = ImMax(0.0f, dot3(vtx_normals[v], to_light));
+            float r = ImMin(1.0f, ambient.x + duck_col.x * light_col.x * diff);
+            float g = ImMin(1.0f, ambient.y + duck_col.y * light_col.y * diff);
+            float b = ImMin(1.0f, ambient.z + duck_col.z * light_col.z * diff);
+            vtx_colors[v] = IM_COL32((ImU8)(r * 255), (ImU8)(g * 255), (ImU8)(b * 255), 255);
+        }
+
+        // Map per-vertex colors to index-buffer slots for Gouraud interpolation
+        for (int i = 0; i < DUCK_IDX_COUNT; i++)
+            duck_fill_colors[i] = vtx_colors[duck_idx[i]];
+
+        duck_colors_built = true;
+    }
+    if (ImPlot3D::BeginPlot("Gouraud Duck")) {
+        ImPlot3D::SetupAxesLimits(-1, 1, -1, 1, -1, 1);
+        ImPlot3D::PlotMesh("Duck", &duck_vtx[0].x, &duck_vtx[0].y, &duck_vtx[0].z, duck_idx, DUCK_VTX_COUNT, DUCK_IDX_COUNT, {
+            ImPlot3DProp_Stride,     (int)sizeof(ImPlot3DPoint),
+            ImPlot3DProp_FillColors, duck_fill_colors,
+            ImPlot3DProp_Flags,      (int)ImPlot3DMeshFlags_NoLines
+        });
+        ImPlot3D::EndPlot();
+    }
 }
 
 //-----------------------------------------------------------------------------

--- a/implot3d_items.cpp
+++ b/implot3d_items.cpp
@@ -344,9 +344,9 @@ struct RendererBase {
     const unsigned int VtxConsumed; // Number of vertices consumed per primitive
 };
 
-template <class _Getter> struct RendererMarkersFill : RendererBase {
-    RendererMarkersFill(const _Getter& getter, const ImVec2* marker, int count, float size, ImU32 col)
-        : RendererBase(getter.Count, (count - 2) * 3, count), Getter(getter), Marker(marker), Count(count), Size(size), Col(col) {}
+template <class _Getter, class _GetterColor, class _GetterSize> struct RendererMarkersFill : RendererBase {
+    RendererMarkersFill(const _Getter& getter, const _GetterColor& col_getter, const _GetterSize& size_getter, const ImVec2* marker, int count)
+        : RendererBase(getter.Count, (count - 2) * 3, count), Getter(getter), ColGetter(col_getter), SizeGetter(size_getter), Marker(marker), Count(count) {}
 
     void Init(ImDrawList3D& draw_list_3d) const { UV = draw_list_3d._SharedData->TexUvWhitePixel; }
 
@@ -355,12 +355,14 @@ template <class _Getter> struct RendererMarkersFill : RendererBase {
         if (!cull_box.Contains(p_plot))
             return false;
         ImVec2 p = PlotToPixels(p_plot);
+        ImU32 col = ColGetter(prim);
+        float size = SizeGetter(prim);
         // 3 vertices per triangle
         for (int i = 0; i < Count; i++) {
-            draw_list_3d._VtxWritePtr[0].pos.x = p.x + Marker[i].x * Size;
-            draw_list_3d._VtxWritePtr[0].pos.y = p.y + Marker[i].y * Size;
+            draw_list_3d._VtxWritePtr[0].pos.x = p.x + Marker[i].x * size;
+            draw_list_3d._VtxWritePtr[0].pos.y = p.y + Marker[i].y * size;
             draw_list_3d._VtxWritePtr[0].uv = UV;
-            draw_list_3d._VtxWritePtr[0].col = Col;
+            draw_list_3d._VtxWritePtr[0].col = col;
             draw_list_3d._VtxWritePtr++;
         }
         // 3 indices per triangle
@@ -379,17 +381,17 @@ template <class _Getter> struct RendererMarkersFill : RendererBase {
         return true;
     }
     const _Getter& Getter;
+    const _GetterColor ColGetter;
+    const _GetterSize SizeGetter;
     const ImVec2* Marker;
     const int Count;
-    const float Size;
-    const ImU32 Col;
     mutable ImVec2 UV;
 };
 
-template <class _Getter> struct RendererMarkersLine : RendererBase {
-    RendererMarkersLine(const _Getter& getter, const ImVec2* marker, int count, float size, float weight, ImU32 col)
-        : RendererBase(getter.Count, count / 2 * 6, count / 2 * 4), Getter(getter), Marker(marker), Count(count),
-          HalfWeight(ImMax(1.0f, weight) * 0.5f), Size(size), Col(col) {}
+template <class _Getter, class _GetterColor, class _GetterSize> struct RendererMarkersLine : RendererBase {
+    RendererMarkersLine(const _Getter& getter, const _GetterColor& col_getter, const _GetterSize& size_getter, const ImVec2* marker, int count, float weight)
+        : RendererBase(getter.Count, count / 2 * 6, count / 2 * 4), Getter(getter), ColGetter(col_getter), SizeGetter(size_getter),
+          Marker(marker), Count(count), HalfWeight(ImMax(1.0f, weight) * 0.5f) {}
 
     void Init(ImDrawList3D& draw_list_3d) const { GetLineRenderProps(draw_list_3d, HalfWeight, UV0, UV1); }
 
@@ -398,27 +400,29 @@ template <class _Getter> struct RendererMarkersLine : RendererBase {
         if (!cull_box.Contains(p_plot))
             return false;
         ImVec2 p = PlotToPixels(p_plot);
+        ImU32 col = ColGetter(prim);
+        float size = SizeGetter(prim);
         for (int i = 0; i < Count; i = i + 2) {
-            ImVec2 p1(p.x + Marker[i].x * Size, p.y + Marker[i].y * Size);
-            ImVec2 p2(p.x + Marker[i + 1].x * Size, p.y + Marker[i + 1].y * Size);
-            PrimLine(draw_list_3d, p1, p2, HalfWeight, Col, UV0, UV1, GetPointDepth(p_plot));
+            ImVec2 p1(p.x + Marker[i].x * size, p.y + Marker[i].y * size);
+            ImVec2 p2(p.x + Marker[i + 1].x * size, p.y + Marker[i + 1].y * size);
+            PrimLine(draw_list_3d, p1, p2, HalfWeight, col, UV0, UV1, GetPointDepth(p_plot));
         }
         return true;
     }
 
     const _Getter& Getter;
+    const _GetterColor ColGetter;
+    const _GetterSize SizeGetter;
     const ImVec2* Marker;
     const int Count;
     mutable float HalfWeight;
-    const float Size;
-    const ImU32 Col;
     mutable ImVec2 UV0;
     mutable ImVec2 UV1;
 };
 
-template <class _Getter> struct RendererLineStrip : RendererBase {
-    RendererLineStrip(const _Getter& getter, ImU32 col, float weight)
-        : RendererBase(getter.Count - 1, 6, 4), Getter(getter), Col(col), HalfWeight(ImMax(1.0f, weight) * 0.5f) {
+template <class _Getter, class _GetterColor> struct RendererLineStrip : RendererBase {
+    RendererLineStrip(const _Getter& getter, const _GetterColor& col_getter, float weight)
+        : RendererBase(getter.Count - 1, 6, 4), Getter(getter), ColGetter(col_getter), HalfWeight(ImMax(1.0f, weight) * 0.5f) {
         // Initialize the first point in plot coordinates
         P1_plot = Getter(0);
     }
@@ -437,7 +441,7 @@ template <class _Getter> struct RendererLineStrip : RendererBase {
             ImVec2 P1_screen = PlotToPixels(P1_clipped);
             ImVec2 P2_screen = PlotToPixels(P2_clipped);
             // Render the line segment
-            PrimLine(draw_list_3d, P1_screen, P2_screen, HalfWeight, Col, UV0, UV1, GetPointDepth((P1_plot + P2_plot) * 0.5));
+            PrimLine(draw_list_3d, P1_screen, P2_screen, HalfWeight, ColGetter(prim), UV0, UV1, GetPointDepth((P1_plot + P2_plot) * 0.5));
         }
 
         // Update for next segment
@@ -447,16 +451,16 @@ template <class _Getter> struct RendererLineStrip : RendererBase {
     }
 
     const _Getter& Getter;
-    const ImU32 Col;
+    const _GetterColor ColGetter;
     mutable float HalfWeight;
     mutable ImPlot3DPoint P1_plot;
     mutable ImVec2 UV0;
     mutable ImVec2 UV1;
 };
 
-template <class _Getter> struct RendererLineStripSkip : RendererBase {
-    RendererLineStripSkip(const _Getter& getter, ImU32 col, float weight)
-        : RendererBase(getter.Count - 1, 6, 4), Getter(getter), Col(col), HalfWeight(ImMax(1.0f, weight) * 0.5f) {
+template <class _Getter, class _GetterColor> struct RendererLineStripSkip : RendererBase {
+    RendererLineStripSkip(const _Getter& getter, const _GetterColor& col_getter, float weight)
+        : RendererBase(getter.Count - 1, 6, 4), Getter(getter), ColGetter(col_getter), HalfWeight(ImMax(1.0f, weight) * 0.5f) {
         // Initialize the first point in plot coordinates
         P1_plot = Getter(0);
     }
@@ -480,7 +484,7 @@ template <class _Getter> struct RendererLineStripSkip : RendererBase {
                 ImVec2 P1_screen = PlotToPixels(P1_clipped);
                 ImVec2 P2_screen = PlotToPixels(P2_clipped);
                 // Render the line segment
-                PrimLine(draw_list_3d, P1_screen, P2_screen, HalfWeight, Col, UV0, UV1, GetPointDepth((P1_plot + P2_plot) * 0.5));
+                PrimLine(draw_list_3d, P1_screen, P2_screen, HalfWeight, ColGetter(prim), UV0, UV1, GetPointDepth((P1_plot + P2_plot) * 0.5));
             }
         }
 
@@ -492,16 +496,16 @@ template <class _Getter> struct RendererLineStripSkip : RendererBase {
     }
 
     const _Getter& Getter;
-    const ImU32 Col;
+    const _GetterColor ColGetter;
     mutable float HalfWeight;
     mutable ImPlot3DPoint P1_plot;
     mutable ImVec2 UV0;
     mutable ImVec2 UV1;
 };
 
-template <class _Getter> struct RendererLineSegments : RendererBase {
-    RendererLineSegments(const _Getter& getter, ImU32 col, float weight)
-        : RendererBase(getter.Count / 2, 6, 4), Getter(getter), Col(col), HalfWeight(ImMax(1.0f, weight) * 0.5f) {}
+template <class _Getter, class _GetterColor> struct RendererLineSegments : RendererBase {
+    RendererLineSegments(const _Getter& getter, const _GetterColor& col_getter, float weight)
+        : RendererBase(getter.Count / 2, 6, 4), Getter(getter), ColGetter(col_getter), HalfWeight(ImMax(1.0f, weight) * 0.5f) {}
 
     void Init(ImDrawList3D& draw_list_3d) const { GetLineRenderProps(draw_list_3d, HalfWeight, UV0, UV1); }
 
@@ -522,7 +526,7 @@ template <class _Getter> struct RendererLineSegments : RendererBase {
                 ImVec2 P1_screen = PlotToPixels(P1_clipped);
                 ImVec2 P2_screen = PlotToPixels(P2_clipped);
                 // Render the line segment
-                PrimLine(draw_list_3d, P1_screen, P2_screen, HalfWeight, Col, UV0, UV1, GetPointDepth((P1_plot + P2_plot) * 0.5));
+                PrimLine(draw_list_3d, P1_screen, P2_screen, HalfWeight, ColGetter(prim), UV0, UV1, GetPointDepth((P1_plot + P2_plot) * 0.5));
             }
             return visible;
         }
@@ -531,14 +535,14 @@ template <class _Getter> struct RendererLineSegments : RendererBase {
     }
 
     const _Getter& Getter;
-    const ImU32 Col;
+    const _GetterColor ColGetter;
     mutable float HalfWeight;
     mutable ImVec2 UV0;
     mutable ImVec2 UV1;
 };
 
-template <class _Getter> struct RendererTriangleFill : RendererBase {
-    RendererTriangleFill(const _Getter& getter, ImU32 col) : RendererBase(getter.Count / 3, 3, 3), Getter(getter), Col(col) {}
+template <class _Getter, class _GetterColor> struct RendererTriangleFill : RendererBase {
+    RendererTriangleFill(const _Getter& getter, const _GetterColor& col_getter) : RendererBase(getter.Count / 3, 3, 3), Getter(getter), ColGetter(col_getter) {}
 
     void Init(ImDrawList3D& draw_list_3d) const { UV = draw_list_3d._SharedData->TexUvWhitePixel; }
 
@@ -558,19 +562,21 @@ template <class _Getter> struct RendererTriangleFill : RendererBase {
         p[1] = PlotToPixels(p_plot[1]);
         p[2] = PlotToPixels(p_plot[2]);
 
+        ImU32 col = ColGetter(prim);
+
         // 3 vertices per triangle
         draw_list_3d._VtxWritePtr[0].pos.x = p[0].x;
         draw_list_3d._VtxWritePtr[0].pos.y = p[0].y;
         draw_list_3d._VtxWritePtr[0].uv = UV;
-        draw_list_3d._VtxWritePtr[0].col = Col;
+        draw_list_3d._VtxWritePtr[0].col = col;
         draw_list_3d._VtxWritePtr[1].pos.x = p[1].x;
         draw_list_3d._VtxWritePtr[1].pos.y = p[1].y;
         draw_list_3d._VtxWritePtr[1].uv = UV;
-        draw_list_3d._VtxWritePtr[1].col = Col;
+        draw_list_3d._VtxWritePtr[1].col = col;
         draw_list_3d._VtxWritePtr[2].pos.x = p[2].x;
         draw_list_3d._VtxWritePtr[2].pos.y = p[2].y;
         draw_list_3d._VtxWritePtr[2].uv = UV;
-        draw_list_3d._VtxWritePtr[2].col = Col;
+        draw_list_3d._VtxWritePtr[2].col = col;
         draw_list_3d._VtxWritePtr += 3;
 
         // 3 indices per triangle
@@ -589,12 +595,12 @@ template <class _Getter> struct RendererTriangleFill : RendererBase {
     }
 
     const _Getter& Getter;
+    const _GetterColor ColGetter;
     mutable ImVec2 UV;
-    const ImU32 Col;
 };
 
-template <class _Getter> struct RendererQuadFill : RendererBase {
-    RendererQuadFill(const _Getter& getter, ImU32 col) : RendererBase(getter.Count / 4, 6, 4), Getter(getter), Col(col) {}
+template <class _Getter, class _GetterColor> struct RendererQuadFill : RendererBase {
+    RendererQuadFill(const _Getter& getter, const _GetterColor& col_getter) : RendererBase(getter.Count / 4, 6, 4), Getter(getter), ColGetter(col_getter) {}
 
     void Init(ImDrawList3D& draw_list_3d) const { UV = draw_list_3d._SharedData->TexUvWhitePixel; }
 
@@ -616,26 +622,28 @@ template <class _Getter> struct RendererQuadFill : RendererBase {
         p[2] = PlotToPixels(p_plot[2]);
         p[3] = PlotToPixels(p_plot[3]);
 
+        ImU32 col = ColGetter(prim);
+
         // Add vertices for two triangles
         draw_list_3d._VtxWritePtr[0].pos.x = p[0].x;
         draw_list_3d._VtxWritePtr[0].pos.y = p[0].y;
         draw_list_3d._VtxWritePtr[0].uv = UV;
-        draw_list_3d._VtxWritePtr[0].col = Col;
+        draw_list_3d._VtxWritePtr[0].col = col;
 
         draw_list_3d._VtxWritePtr[1].pos.x = p[1].x;
         draw_list_3d._VtxWritePtr[1].pos.y = p[1].y;
         draw_list_3d._VtxWritePtr[1].uv = UV;
-        draw_list_3d._VtxWritePtr[1].col = Col;
+        draw_list_3d._VtxWritePtr[1].col = col;
 
         draw_list_3d._VtxWritePtr[2].pos.x = p[2].x;
         draw_list_3d._VtxWritePtr[2].pos.y = p[2].y;
         draw_list_3d._VtxWritePtr[2].uv = UV;
-        draw_list_3d._VtxWritePtr[2].col = Col;
+        draw_list_3d._VtxWritePtr[2].col = col;
 
         draw_list_3d._VtxWritePtr[3].pos.x = p[3].x;
         draw_list_3d._VtxWritePtr[3].pos.y = p[3].y;
         draw_list_3d._VtxWritePtr[3].uv = UV;
-        draw_list_3d._VtxWritePtr[3].col = Col;
+        draw_list_3d._VtxWritePtr[3].col = col;
 
         draw_list_3d._VtxWritePtr += 4;
 
@@ -663,8 +671,8 @@ template <class _Getter> struct RendererQuadFill : RendererBase {
     }
 
     const _Getter& Getter;
+    const _GetterColor ColGetter;
     mutable ImVec2 UV;
-    const ImU32 Col;
 };
 
 template <class _Getter> struct RendererQuadImage : RendererBase {
@@ -1000,12 +1008,50 @@ struct GetterMeshTriangles {
 };
 
 //-----------------------------------------------------------------------------
+// [SECTION] Color and Size Getters
+//-----------------------------------------------------------------------------
+
+struct GetterConstColor {
+    GetterConstColor(ImU32 col) : Col(col) {}
+    IMPLOT3D_INLINE ImU32 operator()(int) const { return Col; }
+    ImU32 Col;
+};
+
+struct GetterIdxColor {
+    GetterIdxColor(const ImU32* data, int count, float alpha = 1.0f) : Data(data), Count(count), Alpha(alpha) {}
+    IMPLOT3D_INLINE ImU32 operator()(int idx) const {
+        ImU32 col = Data[idx];
+        if (Alpha < 1.0f) {
+            ImVec4 c = ImGui::ColorConvertU32ToFloat4(col);
+            c.w *= Alpha;
+            col = ImGui::ColorConvertFloat4ToU32(c);
+        }
+        return col;
+    }
+    const ImU32* Data;
+    const int Count;
+    const float Alpha;
+};
+
+struct GetterConstSize {
+    GetterConstSize(float size) : Size(size) {}
+    IMPLOT3D_INLINE float operator()(int) const { return Size; }
+    float Size;
+};
+
+struct GetterIdxSize {
+    GetterIdxSize(const float* data, int count) : Data(data), Count(count) {}
+    IMPLOT3D_INLINE float operator()(int idx) const { return Data[idx]; }
+    const float* Data;
+    const int Count;
+};
+
+//-----------------------------------------------------------------------------
 // [SECTION] RenderPrimitives
 //-----------------------------------------------------------------------------
 
-/// Renders primitive shapes
-template <template <class> class _Renderer, class _Getter, typename... Args> void RenderPrimitives(const _Getter& getter, Args... args) {
-    _Renderer<_Getter> renderer(getter, args...);
+/// Renders primitive shapes (pre-built renderer variant)
+template <class _Renderer> void RenderPrimitivesEx(const _Renderer& renderer) {
     ImPlot3DPlot& plot = *GetCurrentPlot();
     ImDrawList3D& draw_list_3d = plot.DrawList;
     ImPlot3DBox cull_box;
@@ -1033,6 +1079,23 @@ template <template <class> class _Renderer, class _Getter, typename... Args> voi
             num_culled++;
     // Unreserve unused vertices and indices
     draw_list_3d.PrimUnreserve(num_culled * renderer.IdxConsumed, num_culled * renderer.VtxConsumed);
+}
+
+/// Renders primitive shapes (single-template-param renderer convenience wrapper)
+template <template <class> class _Renderer, class _Getter, typename... Args> void RenderPrimitives(const _Getter& getter, Args... args) {
+    RenderPrimitivesEx(_Renderer<_Getter>(getter, args...));
+}
+
+/// Renders primitive shapes (two-getter renderer: point getter + color getter)
+template <template <class, class> class _Renderer, class _Getter1, class _Getter2, typename... Args>
+void RenderPrimitives2(const _Getter1& getter1, const _Getter2& getter2, Args... args) {
+    RenderPrimitivesEx(_Renderer<_Getter1, _Getter2>(getter1, getter2, args...));
+}
+
+/// Renders primitive shapes (three-getter renderer: point getter + color getter + size getter)
+template <template <class, class, class> class _Renderer, class _Getter1, class _Getter2, class _Getter3, typename... Args>
+void RenderPrimitives3(const _Getter1& getter1, const _Getter2& getter2, const _Getter3& getter3, Args... args) {
+    RenderPrimitivesEx(_Renderer<_Getter1, _Getter2, _Getter3>(getter1, getter2, getter3, args...));
 }
 
 //-----------------------------------------------------------------------------
@@ -1095,33 +1158,41 @@ static const ImVec2 MARKER_LINE_PLUS[4] = {ImVec2(-1, 0), ImVec2(1, 0), ImVec2(0
 static const ImVec2 MARKER_LINE_CROSS[4] = {ImVec2(-SQRT_1_2, -SQRT_1_2), ImVec2(SQRT_1_2, SQRT_1_2), ImVec2(SQRT_1_2, -SQRT_1_2),
                                             ImVec2(-SQRT_1_2, SQRT_1_2)};
 
-template <typename _Getter> void RenderMarkers(const _Getter& getter, ImPlot3DMarker marker, float size, bool rend_fill, ImU32 col_fill,
-                                               bool rend_line, ImU32 col_line, float weight) {
+template <typename _Getter, typename _GetterFillColor, typename _GetterLineColor, typename _GetterSize>
+void RenderMarkers(const _Getter& getter, ImPlot3DMarker marker, bool rend_fill, const _GetterFillColor& col_fill,
+                   bool rend_line, const _GetterLineColor& col_line, const _GetterSize& size, float weight) {
     if (rend_fill) {
         switch (marker) {
-            case ImPlot3DMarker_Circle: RenderPrimitives<RendererMarkersFill>(getter, MARKER_FILL_CIRCLE, 10, size, col_fill); break;
-            case ImPlot3DMarker_Square: RenderPrimitives<RendererMarkersFill>(getter, MARKER_FILL_SQUARE, 4, size, col_fill); break;
-            case ImPlot3DMarker_Diamond: RenderPrimitives<RendererMarkersFill>(getter, MARKER_FILL_DIAMOND, 4, size, col_fill); break;
-            case ImPlot3DMarker_Up: RenderPrimitives<RendererMarkersFill>(getter, MARKER_FILL_UP, 3, size, col_fill); break;
-            case ImPlot3DMarker_Down: RenderPrimitives<RendererMarkersFill>(getter, MARKER_FILL_DOWN, 3, size, col_fill); break;
-            case ImPlot3DMarker_Left: RenderPrimitives<RendererMarkersFill>(getter, MARKER_FILL_LEFT, 3, size, col_fill); break;
-            case ImPlot3DMarker_Right: RenderPrimitives<RendererMarkersFill>(getter, MARKER_FILL_RIGHT, 3, size, col_fill); break;
+            case ImPlot3DMarker_Circle:  RenderPrimitives3<RendererMarkersFill>(getter, col_fill, size, MARKER_FILL_CIRCLE,  10); break;
+            case ImPlot3DMarker_Square:  RenderPrimitives3<RendererMarkersFill>(getter, col_fill, size, MARKER_FILL_SQUARE,   4); break;
+            case ImPlot3DMarker_Diamond: RenderPrimitives3<RendererMarkersFill>(getter, col_fill, size, MARKER_FILL_DIAMOND,  4); break;
+            case ImPlot3DMarker_Up:      RenderPrimitives3<RendererMarkersFill>(getter, col_fill, size, MARKER_FILL_UP,       3); break;
+            case ImPlot3DMarker_Down:    RenderPrimitives3<RendererMarkersFill>(getter, col_fill, size, MARKER_FILL_DOWN,     3); break;
+            case ImPlot3DMarker_Left:    RenderPrimitives3<RendererMarkersFill>(getter, col_fill, size, MARKER_FILL_LEFT,     3); break;
+            case ImPlot3DMarker_Right:   RenderPrimitives3<RendererMarkersFill>(getter, col_fill, size, MARKER_FILL_RIGHT,    3); break;
         }
     }
     if (rend_line) {
         switch (marker) {
-            case ImPlot3DMarker_Circle: RenderPrimitives<RendererMarkersLine>(getter, MARKER_LINE_CIRCLE, 20, size, weight, col_line); break;
-            case ImPlot3DMarker_Square: RenderPrimitives<RendererMarkersLine>(getter, MARKER_LINE_SQUARE, 8, size, weight, col_line); break;
-            case ImPlot3DMarker_Diamond: RenderPrimitives<RendererMarkersLine>(getter, MARKER_LINE_DIAMOND, 8, size, weight, col_line); break;
-            case ImPlot3DMarker_Up: RenderPrimitives<RendererMarkersLine>(getter, MARKER_LINE_UP, 6, size, weight, col_line); break;
-            case ImPlot3DMarker_Down: RenderPrimitives<RendererMarkersLine>(getter, MARKER_LINE_DOWN, 6, size, weight, col_line); break;
-            case ImPlot3DMarker_Left: RenderPrimitives<RendererMarkersLine>(getter, MARKER_LINE_LEFT, 6, size, weight, col_line); break;
-            case ImPlot3DMarker_Right: RenderPrimitives<RendererMarkersLine>(getter, MARKER_LINE_RIGHT, 6, size, weight, col_line); break;
-            case ImPlot3DMarker_Asterisk: RenderPrimitives<RendererMarkersLine>(getter, MARKER_LINE_ASTERISK, 6, size, weight, col_line); break;
-            case ImPlot3DMarker_Plus: RenderPrimitives<RendererMarkersLine>(getter, MARKER_LINE_PLUS, 4, size, weight, col_line); break;
-            case ImPlot3DMarker_Cross: RenderPrimitives<RendererMarkersLine>(getter, MARKER_LINE_CROSS, 4, size, weight, col_line); break;
+            case ImPlot3DMarker_Circle:   RenderPrimitives3<RendererMarkersLine>(getter, col_line, size, MARKER_LINE_CIRCLE,   20, weight); break;
+            case ImPlot3DMarker_Square:   RenderPrimitives3<RendererMarkersLine>(getter, col_line, size, MARKER_LINE_SQUARE,    8, weight); break;
+            case ImPlot3DMarker_Diamond:  RenderPrimitives3<RendererMarkersLine>(getter, col_line, size, MARKER_LINE_DIAMOND,   8, weight); break;
+            case ImPlot3DMarker_Up:       RenderPrimitives3<RendererMarkersLine>(getter, col_line, size, MARKER_LINE_UP,        6, weight); break;
+            case ImPlot3DMarker_Down:     RenderPrimitives3<RendererMarkersLine>(getter, col_line, size, MARKER_LINE_DOWN,      6, weight); break;
+            case ImPlot3DMarker_Left:     RenderPrimitives3<RendererMarkersLine>(getter, col_line, size, MARKER_LINE_LEFT,      6, weight); break;
+            case ImPlot3DMarker_Right:    RenderPrimitives3<RendererMarkersLine>(getter, col_line, size, MARKER_LINE_RIGHT,     6, weight); break;
+            case ImPlot3DMarker_Asterisk: RenderPrimitives3<RendererMarkersLine>(getter, col_line, size, MARKER_LINE_ASTERISK,  6, weight); break;
+            case ImPlot3DMarker_Plus:     RenderPrimitives3<RendererMarkersLine>(getter, col_line, size, MARKER_LINE_PLUS,      4, weight); break;
+            case ImPlot3DMarker_Cross:    RenderPrimitives3<RendererMarkersLine>(getter, col_line, size, MARKER_LINE_CROSS,     4, weight); break;
         }
     }
+}
+
+// Convenience wrapper using constant color/size (existing call sites)
+template <typename _Getter>
+void RenderMarkers(const _Getter& getter, ImPlot3DMarker marker, float size, bool rend_fill, ImU32 col_fill,
+                   bool rend_line, ImU32 col_line, float weight) {
+    RenderMarkers(getter, marker, rend_fill, GetterConstColor(col_fill), rend_line, GetterConstColor(col_line), GetterConstSize(size), weight);
 }
 
 //-----------------------------------------------------------------------------
@@ -1166,19 +1237,19 @@ template <typename _Getter> void PlotLineEx(const char* label_id, const _Getter&
         const ImPlot3DSpec& s = n.Spec;
 
         if (getter.Count >= 2 && n.RenderLine) {
-            const ImU32 col_line = ImGui::GetColorU32(s.LineColor);
+            const GetterConstColor col_line(ImGui::GetColorU32(s.LineColor));
             if (ImHasFlag(spec.Flags, ImPlot3DLineFlags_Segments)) {
-                RenderPrimitives<RendererLineSegments>(getter, col_line, s.LineWeight);
+                RenderPrimitives2<RendererLineSegments>(getter, col_line, s.LineWeight);
             } else if (ImHasFlag(spec.Flags, ImPlot3DLineFlags_Loop)) {
                 if (ImHasFlag(spec.Flags, ImPlot3DLineFlags_SkipNaN))
-                    RenderPrimitives<RendererLineStripSkip>(GetterLoop<_Getter>(getter), col_line, s.LineWeight);
+                    RenderPrimitives2<RendererLineStripSkip>(GetterLoop<_Getter>(getter), col_line, s.LineWeight);
                 else
-                    RenderPrimitives<RendererLineStrip>(GetterLoop<_Getter>(getter), col_line, s.LineWeight);
+                    RenderPrimitives2<RendererLineStrip>(GetterLoop<_Getter>(getter), col_line, s.LineWeight);
             } else {
                 if (ImHasFlag(spec.Flags, ImPlot3DLineFlags_SkipNaN))
-                    RenderPrimitives<RendererLineStripSkip>(getter, col_line, s.LineWeight);
+                    RenderPrimitives2<RendererLineStripSkip>(getter, col_line, s.LineWeight);
                 else
-                    RenderPrimitives<RendererLineStrip>(getter, col_line, s.LineWeight);
+                    RenderPrimitives2<RendererLineStrip>(getter, col_line, s.LineWeight);
             }
         }
 
@@ -1218,14 +1289,12 @@ template <typename _Getter> void PlotTriangleEx(const char* label_id, const _Get
 
         // Render fill
         if (getter.Count >= 3 && n.RenderFill && !ImHasFlag(spec.Flags, ImPlot3DTriangleFlags_NoFill)) {
-            const ImU32 col_fill = ImGui::GetColorU32(s.FillColor);
-            RenderPrimitives<RendererTriangleFill>(getter, col_fill);
+            RenderPrimitives2<RendererTriangleFill>(getter, GetterConstColor(ImGui::GetColorU32(s.FillColor)));
         }
 
         // Render lines
         if (getter.Count >= 2 && n.RenderLine && !ImHasFlag(spec.Flags, ImPlot3DTriangleFlags_NoLines)) {
-            const ImU32 col_line = ImGui::GetColorU32(s.LineColor);
-            RenderPrimitives<RendererLineSegments>(GetterTriangleLines<_Getter>(getter), col_line, s.LineWeight);
+            RenderPrimitives2<RendererLineSegments>(GetterTriangleLines<_Getter>(getter), GetterConstColor(ImGui::GetColorU32(s.LineColor)), s.LineWeight);
         }
 
         // Render markers
@@ -1265,14 +1334,12 @@ template <typename _Getter> void PlotQuadEx(const char* label_id, const _Getter&
 
         // Render fill
         if (getter.Count >= 4 && n.RenderFill && !ImHasFlag(spec.Flags, ImPlot3DQuadFlags_NoFill)) {
-            const ImU32 col_fill = ImGui::GetColorU32(s.FillColor);
-            RenderPrimitives<RendererQuadFill>(getter, col_fill);
+            RenderPrimitives2<RendererQuadFill>(getter, GetterConstColor(ImGui::GetColorU32(s.FillColor)));
         }
 
         // Render lines
         if (getter.Count >= 2 && n.RenderLine && !ImHasFlag(spec.Flags, ImPlot3DQuadFlags_NoLines)) {
-            const ImU32 col_line = ImGui::GetColorU32(s.LineColor);
-            RenderPrimitives<RendererLineSegments>(GetterQuadLines<_Getter>(getter), col_line, s.LineWeight);
+            RenderPrimitives2<RendererLineSegments>(GetterQuadLines<_Getter>(getter), GetterConstColor(ImGui::GetColorU32(s.LineColor)), s.LineWeight);
         }
 
         // Render markers
@@ -1319,8 +1386,7 @@ template <typename _Getter> void PlotSurfaceEx(const char* label_id, const _Gett
 
         // Render lines
         if (getter.Count >= 2 && n.RenderLine && !ImHasFlag(spec.Flags, ImPlot3DSurfaceFlags_NoLines)) {
-            const ImU32 col_line = ImGui::GetColorU32(s.LineColor);
-            RenderPrimitives<RendererLineSegments>(GetterSurfaceLines<_Getter>(getter, x_count, y_count), col_line, s.LineWeight);
+            RenderPrimitives2<RendererLineSegments>(GetterSurfaceLines<_Getter>(getter, x_count, y_count), GetterConstColor(ImGui::GetColorU32(s.LineColor)), s.LineWeight);
         }
 
         // Render markers
@@ -1366,14 +1432,12 @@ void PlotMesh(const char* label_id, const ImPlot3DPoint* vtx, const unsigned int
 
         // Render fill
         if (getter.Count >= 3 && n.RenderFill && !ImHasFlag(spec.Flags, ImPlot3DMeshFlags_NoFill)) {
-            const ImU32 col_fill = ImGui::GetColorU32(s.FillColor);
-            RenderPrimitives<RendererTriangleFill>(getter_triangles, col_fill);
+            RenderPrimitives2<RendererTriangleFill>(getter_triangles, GetterConstColor(ImGui::GetColorU32(s.FillColor)));
         }
 
         // Render lines
         if (getter.Count >= 2 && n.RenderLine && !n.IsAutoLine && !ImHasFlag(spec.Flags, ImPlot3DMeshFlags_NoLines)) {
-            const ImU32 col_line = ImGui::GetColorU32(s.LineColor);
-            RenderPrimitives<RendererLineSegments>(GetterTriangleLines<GetterMeshTriangles>(getter_triangles), col_line, s.LineWeight);
+            RenderPrimitives2<RendererLineSegments>(GetterTriangleLines<GetterMeshTriangles>(getter_triangles), GetterConstColor(ImGui::GetColorU32(s.LineColor)), s.LineWeight);
         }
 
         // Render markers

--- a/implot3d_items.cpp
+++ b/implot3d_items.cpp
@@ -792,7 +792,16 @@ template <class _Getter> struct RendererSurfaceFill : RendererBase {
         // Compute colors
         ImU32 cols[4] = {Col, Col, Col, Col};
         const ImPlot3DNextItemData& n = GetItemData();
-        if (n.IsAutoFill) {
+        const int vtx_idx[4] = {x + y * XCount, x + 1 + y * XCount, x + 1 + (y + 1) * XCount, x + (y + 1) * XCount};
+        if (n.Spec.FillColors != nullptr) {
+            float alpha = n.Spec.FillAlpha;
+            for (int i = 0; i < 4; i++) {
+                ImU32 c = n.Spec.FillColors[vtx_idx[i]];
+                ImVec4 cv = ImGui::ColorConvertU32ToFloat4(c);
+                cv.w *= alpha;
+                cols[i] = ImGui::ColorConvertFloat4ToU32(cv);
+            }
+        } else if (n.IsAutoFill) {
             float alpha = GImPlot3D->NextItemData.Spec.FillAlpha;
             double min = Min;
             double max = Max;
@@ -1432,15 +1441,15 @@ template <typename _Getter> void PlotSurfaceEx(const char* label_id, const _Gett
 
         // Render lines
         if (getter.Count >= 2 && n.RenderLine && !ImHasFlag(spec.Flags, ImPlot3DSurfaceFlags_NoLines)) {
-            RenderPrimitives2<RendererLineSegments>(GetterSurfaceLines<_Getter>(getter, x_count, y_count), GetterConstColor(ImGui::GetColorU32(s.LineColor)), s.LineWeight);
+            if (s.LineColors != nullptr)
+                RenderPrimitives2<RendererLineSegments>(GetterSurfaceLines<_Getter>(getter, x_count, y_count), GetterIdxColor(s.LineColors, getter.Count), s.LineWeight);
+            else
+                RenderPrimitives2<RendererLineSegments>(GetterSurfaceLines<_Getter>(getter, x_count, y_count), GetterConstColor(ImGui::GetColorU32(s.LineColor)), s.LineWeight);
         }
 
         // Render markers
-        if (s.Marker != ImPlot3DMarker_None && !ImHasFlag(spec.Flags, ImPlot3DSurfaceFlags_NoMarkers)) {
-            const ImU32 col_line = ImGui::GetColorU32(s.MarkerLineColor);
-            const ImU32 col_fill = ImGui::GetColorU32(s.MarkerFillColor);
-            RenderMarkers<_Getter>(getter, s.Marker, s.MarkerSize, n.RenderMarkerFill, col_fill, n.RenderMarkerLine, col_line, s.LineWeight);
-        }
+        if (s.Marker != ImPlot3DMarker_None && !ImHasFlag(spec.Flags, ImPlot3DSurfaceFlags_NoMarkers))
+            RenderColoredMarkers(getter, n);
 
         EndItem();
     }

--- a/implot3d_items.cpp
+++ b/implot3d_items.cpp
@@ -1195,19 +1195,49 @@ void RenderMarkers(const _Getter& getter, ImPlot3DMarker marker, float size, boo
     RenderMarkers(getter, marker, rend_fill, GetterConstColor(col_fill), rend_line, GetterConstColor(col_line), GetterConstSize(size), weight);
 }
 
+template <typename _Getter>
+void RenderColoredMarkers(const _Getter& getter, const ImPlot3DNextItemData& n) {
+    const ImPlot3DSpec& s = n.Spec;
+    const ImU32 col_line = ImGui::GetColorU32(s.MarkerLineColor);
+    const ImU32 col_fill = ImGui::GetColorU32(s.MarkerFillColor);
+    if (s.MarkerSizes != nullptr) {
+        GetterIdxSize size_getter(s.MarkerSizes, getter.Count);
+        if (s.MarkerFillColors != nullptr && s.MarkerLineColors != nullptr) {
+            RenderMarkers(getter, s.Marker, n.RenderMarkerFill, GetterIdxColor(s.MarkerFillColors, getter.Count, s.FillAlpha), n.RenderMarkerLine, GetterIdxColor(s.MarkerLineColors, getter.Count), size_getter, s.LineWeight);
+        } else if (s.MarkerFillColors != nullptr) {
+            RenderMarkers(getter, s.Marker, n.RenderMarkerFill, GetterIdxColor(s.MarkerFillColors, getter.Count, s.FillAlpha), n.RenderMarkerLine, GetterConstColor(col_line), size_getter, s.LineWeight);
+        } else if (s.MarkerLineColors != nullptr) {
+            RenderMarkers(getter, s.Marker, n.RenderMarkerFill, GetterConstColor(col_fill), n.RenderMarkerLine, GetterIdxColor(s.MarkerLineColors, getter.Count), size_getter, s.LineWeight);
+        } else {
+            RenderMarkers(getter, s.Marker, n.RenderMarkerFill, GetterConstColor(col_fill), n.RenderMarkerLine, GetterConstColor(col_line), size_getter, s.LineWeight);
+        }
+    } else {
+        GetterConstSize size_getter(s.MarkerSize);
+        if (s.MarkerFillColors != nullptr && s.MarkerLineColors != nullptr) {
+            RenderMarkers(getter, s.Marker, n.RenderMarkerFill, GetterIdxColor(s.MarkerFillColors, getter.Count, s.FillAlpha), n.RenderMarkerLine, GetterIdxColor(s.MarkerLineColors, getter.Count), size_getter, s.LineWeight);
+        } else if (s.MarkerFillColors != nullptr) {
+            RenderMarkers(getter, s.Marker, n.RenderMarkerFill, GetterIdxColor(s.MarkerFillColors, getter.Count, s.FillAlpha), n.RenderMarkerLine, GetterConstColor(col_line), size_getter, s.LineWeight);
+        } else if (s.MarkerLineColors != nullptr) {
+            RenderMarkers(getter, s.Marker, n.RenderMarkerFill, GetterConstColor(col_fill), n.RenderMarkerLine, GetterIdxColor(s.MarkerLineColors, getter.Count), size_getter, s.LineWeight);
+        } else {
+            RenderMarkers(getter, s.Marker, n.RenderMarkerFill, GetterConstColor(col_fill), n.RenderMarkerLine, GetterConstColor(col_line), size_getter, s.LineWeight);
+        }
+    }
+}
+
 //-----------------------------------------------------------------------------
 // [SECTION] PlotScatter
 //-----------------------------------------------------------------------------
 
 template <typename Getter> void PlotScatterEx(const char* label_id, const Getter& getter, const ImPlot3DSpec& spec) {
     if (BeginItemEx(label_id, getter, spec, spec.MarkerLineColor, spec.Marker)) {
-        const ImPlot3DNextItemData& n = GetItemData();
-        const ImPlot3DSpec& s = n.Spec;
-        ImPlot3DMarker marker = s.Marker == ImPlot3DMarker_None ? ImPlot3DMarker_Circle : s.Marker;
-        const ImU32 col_line = ImGui::GetColorU32(s.MarkerLineColor);
-        const ImU32 col_fill = ImGui::GetColorU32(s.MarkerFillColor);
-        if (marker != ImPlot3DMarker_None)
-            RenderMarkers<Getter>(getter, marker, s.MarkerSize, n.RenderMarkerFill, col_fill, n.RenderMarkerLine, col_line, s.LineWeight);
+        ImPlot3DContext& gp = *GImPlot3D;
+        ImPlot3DNextItemData& n = gp.NextItemData;
+        // Scatter always renders a marker; default to Circle
+        if (n.Spec.Marker == ImPlot3DMarker_None)
+            n.Spec.Marker = ImPlot3DMarker_Circle;
+        if (n.Spec.Marker != ImPlot3DMarker_None)
+            RenderColoredMarkers(getter, n);
         EndItem();
     }
 }

--- a/implot3d_items.cpp
+++ b/implot3d_items.cpp
@@ -346,7 +346,8 @@ struct RendererBase {
 
 template <class _Getter, class _GetterColor, class _GetterSize> struct RendererMarkersFill : RendererBase {
     RendererMarkersFill(const _Getter& getter, const _GetterColor& col_getter, const _GetterSize& size_getter, const ImVec2* marker, int count)
-        : RendererBase(getter.Count, (count - 2) * 3, count), Getter(getter), ColGetter(col_getter), SizeGetter(size_getter), Marker(marker), Count(count) {}
+        : RendererBase(getter.Count, (count - 2) * 3, count), Getter(getter), ColGetter(col_getter), SizeGetter(size_getter), Marker(marker),
+          Count(count) {}
 
     void Init(ImDrawList3D& draw_list_3d) const { UV = draw_list_3d._SharedData->TexUvWhitePixel; }
 
@@ -389,9 +390,10 @@ template <class _Getter, class _GetterColor, class _GetterSize> struct RendererM
 };
 
 template <class _Getter, class _GetterColor, class _GetterSize> struct RendererMarkersLine : RendererBase {
-    RendererMarkersLine(const _Getter& getter, const _GetterColor& col_getter, const _GetterSize& size_getter, const ImVec2* marker, int count, float weight)
-        : RendererBase(getter.Count, count / 2 * 6, count / 2 * 4), Getter(getter), ColGetter(col_getter), SizeGetter(size_getter),
-          Marker(marker), Count(count), HalfWeight(ImMax(1.0f, weight) * 0.5f) {}
+    RendererMarkersLine(const _Getter& getter, const _GetterColor& col_getter, const _GetterSize& size_getter, const ImVec2* marker, int count,
+                        float weight)
+        : RendererBase(getter.Count, count / 2 * 6, count / 2 * 4), Getter(getter), ColGetter(col_getter), SizeGetter(size_getter), Marker(marker),
+          Count(count), HalfWeight(ImMax(1.0f, weight) * 0.5f) {}
 
     void Init(ImDrawList3D& draw_list_3d) const { GetLineRenderProps(draw_list_3d, HalfWeight, UV0, UV1); }
 
@@ -542,7 +544,8 @@ template <class _Getter, class _GetterColor> struct RendererLineSegments : Rende
 };
 
 template <class _Getter, class _GetterColor> struct RendererTriangleFill : RendererBase {
-    RendererTriangleFill(const _Getter& getter, const _GetterColor& col_getter) : RendererBase(getter.Count / 3, 3, 3), Getter(getter), ColGetter(col_getter) {}
+    RendererTriangleFill(const _Getter& getter, const _GetterColor& col_getter)
+        : RendererBase(getter.Count / 3, 3, 3), Getter(getter), ColGetter(col_getter) {}
 
     void Init(ImDrawList3D& draw_list_3d) const { UV = draw_list_3d._SharedData->TexUvWhitePixel; }
 
@@ -598,7 +601,8 @@ template <class _Getter, class _GetterColor> struct RendererTriangleFill : Rende
 };
 
 template <class _Getter, class _GetterColor> struct RendererQuadFill : RendererBase {
-    RendererQuadFill(const _Getter& getter, const _GetterColor& col_getter) : RendererBase(getter.Count / 4, 6, 4), Getter(getter), ColGetter(col_getter) {}
+    RendererQuadFill(const _Getter& getter, const _GetterColor& col_getter)
+        : RendererBase(getter.Count / 4, 6, 4), Getter(getter), ColGetter(col_getter) {}
 
     void Init(ImDrawList3D& draw_list_3d) const { UV = draw_list_3d._SharedData->TexUvWhitePixel; }
 
@@ -1165,68 +1169,74 @@ static const ImVec2 MARKER_LINE_CROSS[4] = {ImVec2(-SQRT_1_2, -SQRT_1_2), ImVec2
                                             ImVec2(-SQRT_1_2, SQRT_1_2)};
 
 template <typename _Getter, typename _GetterFillColor, typename _GetterLineColor, typename _GetterSize>
-void RenderMarkers(const _Getter& getter, ImPlot3DMarker marker, bool rend_fill, const _GetterFillColor& col_fill,
-                   bool rend_line, const _GetterLineColor& col_line, const _GetterSize& size, float weight) {
+void RenderMarkers(const _Getter& getter, ImPlot3DMarker marker, bool rend_fill, const _GetterFillColor& col_fill, bool rend_line,
+                   const _GetterLineColor& col_line, const _GetterSize& size, float weight) {
     if (rend_fill) {
         switch (marker) {
-            case ImPlot3DMarker_Circle:  RenderPrimitives3<RendererMarkersFill>(getter, col_fill, size, MARKER_FILL_CIRCLE,  10); break;
-            case ImPlot3DMarker_Square:  RenderPrimitives3<RendererMarkersFill>(getter, col_fill, size, MARKER_FILL_SQUARE,   4); break;
-            case ImPlot3DMarker_Diamond: RenderPrimitives3<RendererMarkersFill>(getter, col_fill, size, MARKER_FILL_DIAMOND,  4); break;
-            case ImPlot3DMarker_Up:      RenderPrimitives3<RendererMarkersFill>(getter, col_fill, size, MARKER_FILL_UP,       3); break;
-            case ImPlot3DMarker_Down:    RenderPrimitives3<RendererMarkersFill>(getter, col_fill, size, MARKER_FILL_DOWN,     3); break;
-            case ImPlot3DMarker_Left:    RenderPrimitives3<RendererMarkersFill>(getter, col_fill, size, MARKER_FILL_LEFT,     3); break;
-            case ImPlot3DMarker_Right:   RenderPrimitives3<RendererMarkersFill>(getter, col_fill, size, MARKER_FILL_RIGHT,    3); break;
+            case ImPlot3DMarker_Circle: RenderPrimitives3<RendererMarkersFill>(getter, col_fill, size, MARKER_FILL_CIRCLE, 10); break;
+            case ImPlot3DMarker_Square: RenderPrimitives3<RendererMarkersFill>(getter, col_fill, size, MARKER_FILL_SQUARE, 4); break;
+            case ImPlot3DMarker_Diamond: RenderPrimitives3<RendererMarkersFill>(getter, col_fill, size, MARKER_FILL_DIAMOND, 4); break;
+            case ImPlot3DMarker_Up: RenderPrimitives3<RendererMarkersFill>(getter, col_fill, size, MARKER_FILL_UP, 3); break;
+            case ImPlot3DMarker_Down: RenderPrimitives3<RendererMarkersFill>(getter, col_fill, size, MARKER_FILL_DOWN, 3); break;
+            case ImPlot3DMarker_Left: RenderPrimitives3<RendererMarkersFill>(getter, col_fill, size, MARKER_FILL_LEFT, 3); break;
+            case ImPlot3DMarker_Right: RenderPrimitives3<RendererMarkersFill>(getter, col_fill, size, MARKER_FILL_RIGHT, 3); break;
         }
     }
     if (rend_line) {
         switch (marker) {
-            case ImPlot3DMarker_Circle:   RenderPrimitives3<RendererMarkersLine>(getter, col_line, size, MARKER_LINE_CIRCLE,   20, weight); break;
-            case ImPlot3DMarker_Square:   RenderPrimitives3<RendererMarkersLine>(getter, col_line, size, MARKER_LINE_SQUARE,    8, weight); break;
-            case ImPlot3DMarker_Diamond:  RenderPrimitives3<RendererMarkersLine>(getter, col_line, size, MARKER_LINE_DIAMOND,   8, weight); break;
-            case ImPlot3DMarker_Up:       RenderPrimitives3<RendererMarkersLine>(getter, col_line, size, MARKER_LINE_UP,        6, weight); break;
-            case ImPlot3DMarker_Down:     RenderPrimitives3<RendererMarkersLine>(getter, col_line, size, MARKER_LINE_DOWN,      6, weight); break;
-            case ImPlot3DMarker_Left:     RenderPrimitives3<RendererMarkersLine>(getter, col_line, size, MARKER_LINE_LEFT,      6, weight); break;
-            case ImPlot3DMarker_Right:    RenderPrimitives3<RendererMarkersLine>(getter, col_line, size, MARKER_LINE_RIGHT,     6, weight); break;
-            case ImPlot3DMarker_Asterisk: RenderPrimitives3<RendererMarkersLine>(getter, col_line, size, MARKER_LINE_ASTERISK,  6, weight); break;
-            case ImPlot3DMarker_Plus:     RenderPrimitives3<RendererMarkersLine>(getter, col_line, size, MARKER_LINE_PLUS,      4, weight); break;
-            case ImPlot3DMarker_Cross:    RenderPrimitives3<RendererMarkersLine>(getter, col_line, size, MARKER_LINE_CROSS,     4, weight); break;
+            case ImPlot3DMarker_Circle: RenderPrimitives3<RendererMarkersLine>(getter, col_line, size, MARKER_LINE_CIRCLE, 20, weight); break;
+            case ImPlot3DMarker_Square: RenderPrimitives3<RendererMarkersLine>(getter, col_line, size, MARKER_LINE_SQUARE, 8, weight); break;
+            case ImPlot3DMarker_Diamond: RenderPrimitives3<RendererMarkersLine>(getter, col_line, size, MARKER_LINE_DIAMOND, 8, weight); break;
+            case ImPlot3DMarker_Up: RenderPrimitives3<RendererMarkersLine>(getter, col_line, size, MARKER_LINE_UP, 6, weight); break;
+            case ImPlot3DMarker_Down: RenderPrimitives3<RendererMarkersLine>(getter, col_line, size, MARKER_LINE_DOWN, 6, weight); break;
+            case ImPlot3DMarker_Left: RenderPrimitives3<RendererMarkersLine>(getter, col_line, size, MARKER_LINE_LEFT, 6, weight); break;
+            case ImPlot3DMarker_Right: RenderPrimitives3<RendererMarkersLine>(getter, col_line, size, MARKER_LINE_RIGHT, 6, weight); break;
+            case ImPlot3DMarker_Asterisk: RenderPrimitives3<RendererMarkersLine>(getter, col_line, size, MARKER_LINE_ASTERISK, 6, weight); break;
+            case ImPlot3DMarker_Plus: RenderPrimitives3<RendererMarkersLine>(getter, col_line, size, MARKER_LINE_PLUS, 4, weight); break;
+            case ImPlot3DMarker_Cross: RenderPrimitives3<RendererMarkersLine>(getter, col_line, size, MARKER_LINE_CROSS, 4, weight); break;
         }
     }
 }
 
 // Convenience wrapper using constant color/size (existing call sites)
-template <typename _Getter>
-void RenderMarkers(const _Getter& getter, ImPlot3DMarker marker, float size, bool rend_fill, ImU32 col_fill,
-                   bool rend_line, ImU32 col_line, float weight) {
+template <typename _Getter> void RenderMarkers(const _Getter& getter, ImPlot3DMarker marker, float size, bool rend_fill, ImU32 col_fill,
+                                               bool rend_line, ImU32 col_line, float weight) {
     RenderMarkers(getter, marker, rend_fill, GetterConstColor(col_fill), rend_line, GetterConstColor(col_line), GetterConstSize(size), weight);
 }
 
-template <typename _Getter>
-void RenderColoredMarkers(const _Getter& getter, const ImPlot3DNextItemData& n) {
+template <typename _Getter> void RenderColoredMarkers(const _Getter& getter, const ImPlot3DNextItemData& n) {
     const ImPlot3DSpec& s = n.Spec;
     const ImU32 col_line = ImGui::GetColorU32(s.MarkerLineColor);
     const ImU32 col_fill = ImGui::GetColorU32(s.MarkerFillColor);
     if (s.MarkerSizes != nullptr) {
         GetterIdxSize size_getter(s.MarkerSizes, getter.Count);
         if (s.MarkerFillColors != nullptr && s.MarkerLineColors != nullptr) {
-            RenderMarkers(getter, s.Marker, n.RenderMarkerFill, GetterIdxColor(s.MarkerFillColors, getter.Count, s.FillAlpha), n.RenderMarkerLine, GetterIdxColor(s.MarkerLineColors, getter.Count), size_getter, s.LineWeight);
+            RenderMarkers(getter, s.Marker, n.RenderMarkerFill, GetterIdxColor(s.MarkerFillColors, getter.Count, s.FillAlpha), n.RenderMarkerLine,
+                          GetterIdxColor(s.MarkerLineColors, getter.Count), size_getter, s.LineWeight);
         } else if (s.MarkerFillColors != nullptr) {
-            RenderMarkers(getter, s.Marker, n.RenderMarkerFill, GetterIdxColor(s.MarkerFillColors, getter.Count, s.FillAlpha), n.RenderMarkerLine, GetterConstColor(col_line), size_getter, s.LineWeight);
+            RenderMarkers(getter, s.Marker, n.RenderMarkerFill, GetterIdxColor(s.MarkerFillColors, getter.Count, s.FillAlpha), n.RenderMarkerLine,
+                          GetterConstColor(col_line), size_getter, s.LineWeight);
         } else if (s.MarkerLineColors != nullptr) {
-            RenderMarkers(getter, s.Marker, n.RenderMarkerFill, GetterConstColor(col_fill), n.RenderMarkerLine, GetterIdxColor(s.MarkerLineColors, getter.Count), size_getter, s.LineWeight);
+            RenderMarkers(getter, s.Marker, n.RenderMarkerFill, GetterConstColor(col_fill), n.RenderMarkerLine,
+                          GetterIdxColor(s.MarkerLineColors, getter.Count), size_getter, s.LineWeight);
         } else {
-            RenderMarkers(getter, s.Marker, n.RenderMarkerFill, GetterConstColor(col_fill), n.RenderMarkerLine, GetterConstColor(col_line), size_getter, s.LineWeight);
+            RenderMarkers(getter, s.Marker, n.RenderMarkerFill, GetterConstColor(col_fill), n.RenderMarkerLine, GetterConstColor(col_line),
+                          size_getter, s.LineWeight);
         }
     } else {
         GetterConstSize size_getter(s.MarkerSize);
         if (s.MarkerFillColors != nullptr && s.MarkerLineColors != nullptr) {
-            RenderMarkers(getter, s.Marker, n.RenderMarkerFill, GetterIdxColor(s.MarkerFillColors, getter.Count, s.FillAlpha), n.RenderMarkerLine, GetterIdxColor(s.MarkerLineColors, getter.Count), size_getter, s.LineWeight);
+            RenderMarkers(getter, s.Marker, n.RenderMarkerFill, GetterIdxColor(s.MarkerFillColors, getter.Count, s.FillAlpha), n.RenderMarkerLine,
+                          GetterIdxColor(s.MarkerLineColors, getter.Count), size_getter, s.LineWeight);
         } else if (s.MarkerFillColors != nullptr) {
-            RenderMarkers(getter, s.Marker, n.RenderMarkerFill, GetterIdxColor(s.MarkerFillColors, getter.Count, s.FillAlpha), n.RenderMarkerLine, GetterConstColor(col_line), size_getter, s.LineWeight);
+            RenderMarkers(getter, s.Marker, n.RenderMarkerFill, GetterIdxColor(s.MarkerFillColors, getter.Count, s.FillAlpha), n.RenderMarkerLine,
+                          GetterConstColor(col_line), size_getter, s.LineWeight);
         } else if (s.MarkerLineColors != nullptr) {
-            RenderMarkers(getter, s.Marker, n.RenderMarkerFill, GetterConstColor(col_fill), n.RenderMarkerLine, GetterIdxColor(s.MarkerLineColors, getter.Count), size_getter, s.LineWeight);
+            RenderMarkers(getter, s.Marker, n.RenderMarkerFill, GetterConstColor(col_fill), n.RenderMarkerLine,
+                          GetterIdxColor(s.MarkerLineColors, getter.Count), size_getter, s.LineWeight);
         } else {
-            RenderMarkers(getter, s.Marker, n.RenderMarkerFill, GetterConstColor(col_fill), n.RenderMarkerLine, GetterConstColor(col_line), size_getter, s.LineWeight);
+            RenderMarkers(getter, s.Marker, n.RenderMarkerFill, GetterConstColor(col_fill), n.RenderMarkerLine, GetterConstColor(col_line),
+                          size_getter, s.LineWeight);
         }
     }
 }
@@ -1282,14 +1292,17 @@ template <typename _Getter> void PlotLineEx(const char* label_id, const _Getter&
             } else if (ImHasFlag(spec.Flags, ImPlot3DLineFlags_Loop)) {
                 if (s.LineColors != nullptr) {
                     if (ImHasFlag(spec.Flags, ImPlot3DLineFlags_SkipNaN))
-                        RenderPrimitives2<RendererLineStripSkip>(GetterLoop<_Getter>(getter), GetterIdxColor(s.LineColors, getter.Count), s.LineWeight);
+                        RenderPrimitives2<RendererLineStripSkip>(GetterLoop<_Getter>(getter), GetterIdxColor(s.LineColors, getter.Count),
+                                                                 s.LineWeight);
                     else
                         RenderPrimitives2<RendererLineStrip>(GetterLoop<_Getter>(getter), GetterIdxColor(s.LineColors, getter.Count), s.LineWeight);
                 } else {
                     if (ImHasFlag(spec.Flags, ImPlot3DLineFlags_SkipNaN))
-                        RenderPrimitives2<RendererLineStripSkip>(GetterLoop<_Getter>(getter), GetterConstColor(ImGui::GetColorU32(s.LineColor)), s.LineWeight);
+                        RenderPrimitives2<RendererLineStripSkip>(GetterLoop<_Getter>(getter), GetterConstColor(ImGui::GetColorU32(s.LineColor)),
+                                                                 s.LineWeight);
                     else
-                        RenderPrimitives2<RendererLineStrip>(GetterLoop<_Getter>(getter), GetterConstColor(ImGui::GetColorU32(s.LineColor)), s.LineWeight);
+                        RenderPrimitives2<RendererLineStrip>(GetterLoop<_Getter>(getter), GetterConstColor(ImGui::GetColorU32(s.LineColor)),
+                                                             s.LineWeight);
                 }
             } else {
                 if (s.LineColors != nullptr) {
@@ -1348,9 +1361,11 @@ template <typename _Getter> void PlotTriangleEx(const char* label_id, const _Get
         // Render lines
         if (getter.Count >= 2 && n.RenderLine && !ImHasFlag(spec.Flags, ImPlot3DTriangleFlags_NoLines)) {
             if (s.LineColors != nullptr)
-                RenderPrimitives2<RendererLineSegments>(GetterTriangleLines<_Getter>(getter), GetterIdxColor(s.LineColors, getter.Count), s.LineWeight);
+                RenderPrimitives2<RendererLineSegments>(GetterTriangleLines<_Getter>(getter), GetterIdxColor(s.LineColors, getter.Count),
+                                                        s.LineWeight);
             else
-                RenderPrimitives2<RendererLineSegments>(GetterTriangleLines<_Getter>(getter), GetterConstColor(ImGui::GetColorU32(s.LineColor)), s.LineWeight);
+                RenderPrimitives2<RendererLineSegments>(GetterTriangleLines<_Getter>(getter), GetterConstColor(ImGui::GetColorU32(s.LineColor)),
+                                                        s.LineWeight);
         }
 
         // Render markers
@@ -1398,7 +1413,8 @@ template <typename _Getter> void PlotQuadEx(const char* label_id, const _Getter&
             if (s.LineColors != nullptr)
                 RenderPrimitives2<RendererLineSegments>(GetterQuadLines<_Getter>(getter), GetterIdxColor(s.LineColors, getter.Count), s.LineWeight);
             else
-                RenderPrimitives2<RendererLineSegments>(GetterQuadLines<_Getter>(getter), GetterConstColor(ImGui::GetColorU32(s.LineColor)), s.LineWeight);
+                RenderPrimitives2<RendererLineSegments>(GetterQuadLines<_Getter>(getter), GetterConstColor(ImGui::GetColorU32(s.LineColor)),
+                                                        s.LineWeight);
         }
 
         // Render markers
@@ -1443,9 +1459,11 @@ template <typename _Getter> void PlotSurfaceEx(const char* label_id, const _Gett
         // Render lines
         if (getter.Count >= 2 && n.RenderLine && !ImHasFlag(spec.Flags, ImPlot3DSurfaceFlags_NoLines)) {
             if (s.LineColors != nullptr)
-                RenderPrimitives2<RendererLineSegments>(GetterSurfaceLines<_Getter>(getter, x_count, y_count), GetterIdxColor(s.LineColors, getter.Count), s.LineWeight);
+                RenderPrimitives2<RendererLineSegments>(GetterSurfaceLines<_Getter>(getter, x_count, y_count),
+                                                        GetterIdxColor(s.LineColors, getter.Count), s.LineWeight);
             else
-                RenderPrimitives2<RendererLineSegments>(GetterSurfaceLines<_Getter>(getter, x_count, y_count), GetterConstColor(ImGui::GetColorU32(s.LineColor)), s.LineWeight);
+                RenderPrimitives2<RendererLineSegments>(GetterSurfaceLines<_Getter>(getter, x_count, y_count),
+                                                        GetterConstColor(ImGui::GetColorU32(s.LineColor)), s.LineWeight);
         }
 
         // Render markers
@@ -1495,9 +1513,11 @@ void PlotMeshEx(const char* label_id, const _VtxGetter& getter, const _TriGetter
         // Render lines
         if (getter.Count >= 2 && n.RenderLine && !n.IsAutoLine && !ImHasFlag(spec.Flags, ImPlot3DMeshFlags_NoLines)) {
             if (s.LineColors != nullptr)
-                RenderPrimitives2<RendererLineSegments>(GetterTriangleLines<_TriGetter>(getter_triangles), GetterIdxColor(s.LineColors, getter_triangles.Count), s.LineWeight);
+                RenderPrimitives2<RendererLineSegments>(GetterTriangleLines<_TriGetter>(getter_triangles),
+                                                        GetterIdxColor(s.LineColors, getter_triangles.Count), s.LineWeight);
             else
-                RenderPrimitives2<RendererLineSegments>(GetterTriangleLines<_TriGetter>(getter_triangles), GetterConstColor(ImGui::GetColorU32(s.LineColor)), s.LineWeight);
+                RenderPrimitives2<RendererLineSegments>(GetterTriangleLines<_TriGetter>(getter_triangles),
+                                                        GetterConstColor(ImGui::GetColorU32(s.LineColor)), s.LineWeight);
         }
 
         // Render markers
@@ -1516,15 +1536,14 @@ IMPLOT3D_TMP void PlotMesh(const char* label_id, const T* vtx_xs, const T* vtx_y
     GetterXYZ<IndexerIdx<T>, IndexerIdx<T>, IndexerIdx<T>> getter(IndexerIdx<T>(vtx_xs, vtx_count, spec.Offset, stride),
                                                                   IndexerIdx<T>(vtx_ys, vtx_count, spec.Offset, stride),
                                                                   IndexerIdx<T>(vtx_zs, vtx_count, spec.Offset, stride), vtx_count);
-    GetterMeshTriangles<IndexerIdx<T>, IndexerIdx<T>, IndexerIdx<T>> getter_triangles(IndexerIdx<T>(vtx_xs, vtx_count, spec.Offset, stride),
-                                                                                      IndexerIdx<T>(vtx_ys, vtx_count, spec.Offset, stride),
-                                                                                      IndexerIdx<T>(vtx_zs, vtx_count, spec.Offset, stride), idxs,
-                                                                                      idx_count);
+    GetterMeshTriangles<IndexerIdx<T>, IndexerIdx<T>, IndexerIdx<T>> getter_triangles(
+        IndexerIdx<T>(vtx_xs, vtx_count, spec.Offset, stride), IndexerIdx<T>(vtx_ys, vtx_count, spec.Offset, stride),
+        IndexerIdx<T>(vtx_zs, vtx_count, spec.Offset, stride), idxs, idx_count);
     PlotMeshEx(label_id, getter, getter_triangles, spec);
 }
 
 #define INSTANTIATE_MACRO(T)                                                                                                                         \
-    template IMPLOT3D_API void PlotMesh<T>(const char* label_id, const T* vtx_xs, const T* vtx_ys, const T* vtx_zs, const unsigned int* idxs,       \
+    template IMPLOT3D_API void PlotMesh<T>(const char* label_id, const T* vtx_xs, const T* vtx_ys, const T* vtx_zs, const unsigned int* idxs,        \
                                            int vtx_count, int idx_count, const ImPlot3DSpec& spec);
 CALL_INSTANTIATE_FOR_NUMERIC_TYPES()
 #undef INSTANTIATE_MACRO

--- a/implot3d_items.cpp
+++ b/implot3d_items.cpp
@@ -562,21 +562,19 @@ template <class _Getter, class _GetterColor> struct RendererTriangleFill : Rende
         p[1] = PlotToPixels(p_plot[1]);
         p[2] = PlotToPixels(p_plot[2]);
 
-        ImU32 col = ColGetter(prim);
-
         // 3 vertices per triangle
         draw_list_3d._VtxWritePtr[0].pos.x = p[0].x;
         draw_list_3d._VtxWritePtr[0].pos.y = p[0].y;
         draw_list_3d._VtxWritePtr[0].uv = UV;
-        draw_list_3d._VtxWritePtr[0].col = col;
+        draw_list_3d._VtxWritePtr[0].col = ColGetter(3 * prim);
         draw_list_3d._VtxWritePtr[1].pos.x = p[1].x;
         draw_list_3d._VtxWritePtr[1].pos.y = p[1].y;
         draw_list_3d._VtxWritePtr[1].uv = UV;
-        draw_list_3d._VtxWritePtr[1].col = col;
+        draw_list_3d._VtxWritePtr[1].col = ColGetter(3 * prim + 1);
         draw_list_3d._VtxWritePtr[2].pos.x = p[2].x;
         draw_list_3d._VtxWritePtr[2].pos.y = p[2].y;
         draw_list_3d._VtxWritePtr[2].uv = UV;
-        draw_list_3d._VtxWritePtr[2].col = col;
+        draw_list_3d._VtxWritePtr[2].col = ColGetter(3 * prim + 2);
         draw_list_3d._VtxWritePtr += 3;
 
         // 3 indices per triangle
@@ -622,28 +620,26 @@ template <class _Getter, class _GetterColor> struct RendererQuadFill : RendererB
         p[2] = PlotToPixels(p_plot[2]);
         p[3] = PlotToPixels(p_plot[3]);
 
-        ImU32 col = ColGetter(prim);
-
         // Add vertices for two triangles
         draw_list_3d._VtxWritePtr[0].pos.x = p[0].x;
         draw_list_3d._VtxWritePtr[0].pos.y = p[0].y;
         draw_list_3d._VtxWritePtr[0].uv = UV;
-        draw_list_3d._VtxWritePtr[0].col = col;
+        draw_list_3d._VtxWritePtr[0].col = ColGetter(4 * prim);
 
         draw_list_3d._VtxWritePtr[1].pos.x = p[1].x;
         draw_list_3d._VtxWritePtr[1].pos.y = p[1].y;
         draw_list_3d._VtxWritePtr[1].uv = UV;
-        draw_list_3d._VtxWritePtr[1].col = col;
+        draw_list_3d._VtxWritePtr[1].col = ColGetter(4 * prim + 1);
 
         draw_list_3d._VtxWritePtr[2].pos.x = p[2].x;
         draw_list_3d._VtxWritePtr[2].pos.y = p[2].y;
         draw_list_3d._VtxWritePtr[2].uv = UV;
-        draw_list_3d._VtxWritePtr[2].col = col;
+        draw_list_3d._VtxWritePtr[2].col = ColGetter(4 * prim + 2);
 
         draw_list_3d._VtxWritePtr[3].pos.x = p[3].x;
         draw_list_3d._VtxWritePtr[3].pos.y = p[3].y;
         draw_list_3d._VtxWritePtr[3].uv = UV;
-        draw_list_3d._VtxWritePtr[3].col = col;
+        draw_list_3d._VtxWritePtr[3].col = ColGetter(4 * prim + 3);
 
         draw_list_3d._VtxWritePtr += 4;
 
@@ -1333,20 +1329,23 @@ template <typename _Getter> void PlotTriangleEx(const char* label_id, const _Get
 
         // Render fill
         if (getter.Count >= 3 && n.RenderFill && !ImHasFlag(spec.Flags, ImPlot3DTriangleFlags_NoFill)) {
-            RenderPrimitives2<RendererTriangleFill>(getter, GetterConstColor(ImGui::GetColorU32(s.FillColor)));
+            if (s.FillColors != nullptr)
+                RenderPrimitives2<RendererTriangleFill>(getter, GetterIdxColor(s.FillColors, getter.Count, s.FillAlpha));
+            else
+                RenderPrimitives2<RendererTriangleFill>(getter, GetterConstColor(ImGui::GetColorU32(s.FillColor)));
         }
 
         // Render lines
         if (getter.Count >= 2 && n.RenderLine && !ImHasFlag(spec.Flags, ImPlot3DTriangleFlags_NoLines)) {
-            RenderPrimitives2<RendererLineSegments>(GetterTriangleLines<_Getter>(getter), GetterConstColor(ImGui::GetColorU32(s.LineColor)), s.LineWeight);
+            if (s.LineColors != nullptr)
+                RenderPrimitives2<RendererLineSegments>(GetterTriangleLines<_Getter>(getter), GetterIdxColor(s.LineColors, getter.Count), s.LineWeight);
+            else
+                RenderPrimitives2<RendererLineSegments>(GetterTriangleLines<_Getter>(getter), GetterConstColor(ImGui::GetColorU32(s.LineColor)), s.LineWeight);
         }
 
         // Render markers
-        if (s.Marker != ImPlot3DMarker_None && !ImHasFlag(spec.Flags, ImPlot3DTriangleFlags_NoMarkers)) {
-            const ImU32 col_line = ImGui::GetColorU32(s.MarkerLineColor);
-            const ImU32 col_fill = ImGui::GetColorU32(s.MarkerFillColor);
-            RenderMarkers<_Getter>(getter, s.Marker, s.MarkerSize, n.RenderMarkerFill, col_fill, n.RenderMarkerLine, col_line, s.LineWeight);
-        }
+        if (s.Marker != ImPlot3DMarker_None && !ImHasFlag(spec.Flags, ImPlot3DTriangleFlags_NoMarkers))
+            RenderColoredMarkers(getter, n);
 
         EndItem();
     }
@@ -1378,20 +1377,23 @@ template <typename _Getter> void PlotQuadEx(const char* label_id, const _Getter&
 
         // Render fill
         if (getter.Count >= 4 && n.RenderFill && !ImHasFlag(spec.Flags, ImPlot3DQuadFlags_NoFill)) {
-            RenderPrimitives2<RendererQuadFill>(getter, GetterConstColor(ImGui::GetColorU32(s.FillColor)));
+            if (s.FillColors != nullptr)
+                RenderPrimitives2<RendererQuadFill>(getter, GetterIdxColor(s.FillColors, getter.Count, s.FillAlpha));
+            else
+                RenderPrimitives2<RendererQuadFill>(getter, GetterConstColor(ImGui::GetColorU32(s.FillColor)));
         }
 
         // Render lines
         if (getter.Count >= 2 && n.RenderLine && !ImHasFlag(spec.Flags, ImPlot3DQuadFlags_NoLines)) {
-            RenderPrimitives2<RendererLineSegments>(GetterQuadLines<_Getter>(getter), GetterConstColor(ImGui::GetColorU32(s.LineColor)), s.LineWeight);
+            if (s.LineColors != nullptr)
+                RenderPrimitives2<RendererLineSegments>(GetterQuadLines<_Getter>(getter), GetterIdxColor(s.LineColors, getter.Count), s.LineWeight);
+            else
+                RenderPrimitives2<RendererLineSegments>(GetterQuadLines<_Getter>(getter), GetterConstColor(ImGui::GetColorU32(s.LineColor)), s.LineWeight);
         }
 
         // Render markers
-        if (s.Marker != ImPlot3DMarker_None && !ImHasFlag(spec.Flags, ImPlot3DQuadFlags_NoMarkers)) {
-            const ImU32 col_line = ImGui::GetColorU32(s.MarkerLineColor);
-            const ImU32 col_fill = ImGui::GetColorU32(s.MarkerFillColor);
-            RenderMarkers<_Getter>(getter, s.Marker, s.MarkerSize, n.RenderMarkerFill, col_fill, n.RenderMarkerLine, col_line, s.LineWeight);
-        }
+        if (s.Marker != ImPlot3DMarker_None && !ImHasFlag(spec.Flags, ImPlot3DQuadFlags_NoMarkers))
+            RenderColoredMarkers(getter, n);
 
         EndItem();
     }

--- a/implot3d_items.cpp
+++ b/implot3d_items.cpp
@@ -1267,28 +1267,42 @@ template <typename _Getter> void PlotLineEx(const char* label_id, const _Getter&
         const ImPlot3DSpec& s = n.Spec;
 
         if (getter.Count >= 2 && n.RenderLine) {
-            const GetterConstColor col_line(ImGui::GetColorU32(s.LineColor));
             if (ImHasFlag(spec.Flags, ImPlot3DLineFlags_Segments)) {
-                RenderPrimitives2<RendererLineSegments>(getter, col_line, s.LineWeight);
+                if (s.LineColors != nullptr) {
+                    RenderPrimitives2<RendererLineSegments>(getter, GetterIdxColor(s.LineColors, getter.Count), s.LineWeight);
+                } else {
+                    RenderPrimitives2<RendererLineSegments>(getter, GetterConstColor(ImGui::GetColorU32(s.LineColor)), s.LineWeight);
+                }
             } else if (ImHasFlag(spec.Flags, ImPlot3DLineFlags_Loop)) {
-                if (ImHasFlag(spec.Flags, ImPlot3DLineFlags_SkipNaN))
-                    RenderPrimitives2<RendererLineStripSkip>(GetterLoop<_Getter>(getter), col_line, s.LineWeight);
-                else
-                    RenderPrimitives2<RendererLineStrip>(GetterLoop<_Getter>(getter), col_line, s.LineWeight);
+                if (s.LineColors != nullptr) {
+                    if (ImHasFlag(spec.Flags, ImPlot3DLineFlags_SkipNaN))
+                        RenderPrimitives2<RendererLineStripSkip>(GetterLoop<_Getter>(getter), GetterIdxColor(s.LineColors, getter.Count), s.LineWeight);
+                    else
+                        RenderPrimitives2<RendererLineStrip>(GetterLoop<_Getter>(getter), GetterIdxColor(s.LineColors, getter.Count), s.LineWeight);
+                } else {
+                    if (ImHasFlag(spec.Flags, ImPlot3DLineFlags_SkipNaN))
+                        RenderPrimitives2<RendererLineStripSkip>(GetterLoop<_Getter>(getter), GetterConstColor(ImGui::GetColorU32(s.LineColor)), s.LineWeight);
+                    else
+                        RenderPrimitives2<RendererLineStrip>(GetterLoop<_Getter>(getter), GetterConstColor(ImGui::GetColorU32(s.LineColor)), s.LineWeight);
+                }
             } else {
-                if (ImHasFlag(spec.Flags, ImPlot3DLineFlags_SkipNaN))
-                    RenderPrimitives2<RendererLineStripSkip>(getter, col_line, s.LineWeight);
-                else
-                    RenderPrimitives2<RendererLineStrip>(getter, col_line, s.LineWeight);
+                if (s.LineColors != nullptr) {
+                    if (ImHasFlag(spec.Flags, ImPlot3DLineFlags_SkipNaN))
+                        RenderPrimitives2<RendererLineStripSkip>(getter, GetterIdxColor(s.LineColors, getter.Count), s.LineWeight);
+                    else
+                        RenderPrimitives2<RendererLineStrip>(getter, GetterIdxColor(s.LineColors, getter.Count), s.LineWeight);
+                } else {
+                    if (ImHasFlag(spec.Flags, ImPlot3DLineFlags_SkipNaN))
+                        RenderPrimitives2<RendererLineStripSkip>(getter, GetterConstColor(ImGui::GetColorU32(s.LineColor)), s.LineWeight);
+                    else
+                        RenderPrimitives2<RendererLineStrip>(getter, GetterConstColor(ImGui::GetColorU32(s.LineColor)), s.LineWeight);
+                }
             }
         }
 
         // Render markers
-        if (s.Marker != ImPlot3DMarker_None) {
-            const ImU32 col_line = ImGui::GetColorU32(s.MarkerLineColor);
-            const ImU32 col_fill = ImGui::GetColorU32(s.MarkerFillColor);
-            RenderMarkers<_Getter>(getter, s.Marker, s.MarkerSize, n.RenderMarkerFill, col_fill, n.RenderMarkerLine, col_line, s.LineWeight);
-        }
+        if (s.Marker != ImPlot3DMarker_None)
+            RenderColoredMarkers(getter, n);
         EndItem();
     }
 }

--- a/implot3d_items.cpp
+++ b/implot3d_items.cpp
@@ -996,18 +996,19 @@ struct Getter3DPoints {
     const int Count;
 };
 
-struct GetterMeshTriangles {
-    GetterMeshTriangles(const ImPlot3DPoint* vtx, const unsigned int* idx, int idx_count)
-        : Vtx(vtx), Idx(idx), IdxCount(idx_count), TriCount(idx_count / 3), Count(idx_count) {}
+template <typename TGX, typename TGY, typename TGZ> struct GetterMeshTriangles {
+    GetterMeshTriangles(TGX gx, TGY gy, TGZ gz, const unsigned int* idx, int idx_count)
+        : Gx(gx), Gy(gy), Gz(gz), Idx(idx), TriCount(idx_count / 3), Count(idx_count) {}
 
     template <typename I> IMPLOT3D_INLINE ImPlot3DPoint operator()(I i) const {
         unsigned int vi = Idx[i];
-        return Vtx[vi];
+        return ImPlot3DPoint(Gx(vi), Gy(vi), Gz(vi));
     }
 
-    const ImPlot3DPoint* Vtx;
+    TGX Gx;
+    TGY Gy;
+    TGZ Gz;
     const unsigned int* Idx;
-    int IdxCount;
     int TriCount;
     int Count;
 };
@@ -1477,23 +1478,19 @@ CALL_INSTANTIATE_FOR_NUMERIC_TYPES()
 // [SECTION] PlotMesh
 //-----------------------------------------------------------------------------
 
-void PlotMesh(const char* label_id, const ImPlot3DPoint* vtx, const unsigned int* idx, int vtx_count, int idx_count, const ImPlot3DSpec& spec) {
-    Getter3DPoints getter(vtx, vtx_count);                     // Get vertices
-    GetterMeshTriangles getter_triangles(vtx, idx, idx_count); // Get triangle vertices
-
+template <typename _VtxGetter, typename _TriGetter>
+void PlotMeshEx(const char* label_id, const _VtxGetter& getter, const _TriGetter& getter_triangles, const ImPlot3DSpec& spec) {
     if (BeginItemEx(label_id, getter, spec, spec.FillColor, spec.Marker)) {
         const ImPlot3DNextItemData& n = GetItemData();
         const ImPlot3DSpec& s = n.Spec;
 
         // Render fill
-        if (getter.Count >= 3 && n.RenderFill && !ImHasFlag(spec.Flags, ImPlot3DMeshFlags_NoFill)) {
+        if (getter.Count >= 3 && n.RenderFill && !ImHasFlag(spec.Flags, ImPlot3DMeshFlags_NoFill))
             RenderPrimitives2<RendererTriangleFill>(getter_triangles, GetterConstColor(ImGui::GetColorU32(s.FillColor)));
-        }
 
         // Render lines
-        if (getter.Count >= 2 && n.RenderLine && !n.IsAutoLine && !ImHasFlag(spec.Flags, ImPlot3DMeshFlags_NoLines)) {
-            RenderPrimitives2<RendererLineSegments>(GetterTriangleLines<GetterMeshTriangles>(getter_triangles), GetterConstColor(ImGui::GetColorU32(s.LineColor)), s.LineWeight);
-        }
+        if (getter.Count >= 2 && n.RenderLine && !n.IsAutoLine && !ImHasFlag(spec.Flags, ImPlot3DMeshFlags_NoLines))
+            RenderPrimitives2<RendererLineSegments>(GetterTriangleLines<_TriGetter>(getter_triangles), GetterConstColor(ImGui::GetColorU32(s.LineColor)), s.LineWeight);
 
         // Render markers
         if (s.Marker != ImPlot3DMarker_None && !ImHasFlag(spec.Flags, ImPlot3DMeshFlags_NoMarkers)) {
@@ -1504,6 +1501,34 @@ void PlotMesh(const char* label_id, const ImPlot3DPoint* vtx, const unsigned int
 
         EndItem();
     }
+}
+
+IMPLOT3D_TMP void PlotMesh(const char* label_id, const T* vtx_xs, const T* vtx_ys, const T* vtx_zs, const unsigned int* idxs, int vtx_count,
+                           int idx_count, const ImPlot3DSpec& spec) {
+    if (vtx_count < 3 || idx_count < 3)
+        return;
+    int stride = Stride<T>(spec);
+    GetterXYZ<IndexerIdx<T>, IndexerIdx<T>, IndexerIdx<T>> getter(IndexerIdx<T>(vtx_xs, vtx_count, spec.Offset, stride),
+                                                                  IndexerIdx<T>(vtx_ys, vtx_count, spec.Offset, stride),
+                                                                  IndexerIdx<T>(vtx_zs, vtx_count, spec.Offset, stride), vtx_count);
+    GetterMeshTriangles<IndexerIdx<T>, IndexerIdx<T>, IndexerIdx<T>> getter_triangles(IndexerIdx<T>(vtx_xs, vtx_count, spec.Offset, stride),
+                                                                                      IndexerIdx<T>(vtx_ys, vtx_count, spec.Offset, stride),
+                                                                                      IndexerIdx<T>(vtx_zs, vtx_count, spec.Offset, stride), idxs,
+                                                                                      idx_count);
+    PlotMeshEx(label_id, getter, getter_triangles, spec);
+}
+
+#define INSTANTIATE_MACRO(T)                                                                                                                         \
+    template IMPLOT3D_API void PlotMesh<T>(const char* label_id, const T* vtx_xs, const T* vtx_ys, const T* vtx_zs, const unsigned int* idxs,       \
+                                           int vtx_count, int idx_count, const ImPlot3DSpec& spec);
+CALL_INSTANTIATE_FOR_NUMERIC_TYPES()
+#undef INSTANTIATE_MACRO
+
+void PlotMesh(const char* label_id, const ImPlot3DPoint* vtx, const unsigned int* idxs, int vtx_count, int idx_count, const ImPlot3DSpec& spec) {
+    ImPlot3DSpec s = spec;
+    s.Offset = 0;
+    s.Stride = (int)sizeof(ImPlot3DPoint);
+    PlotMesh<double>(label_id, &vtx->x, &vtx->y, &vtx->z, idxs, vtx_count, idx_count, s);
 }
 
 //-----------------------------------------------------------------------------

--- a/implot3d_items.cpp
+++ b/implot3d_items.cpp
@@ -1485,19 +1485,24 @@ void PlotMeshEx(const char* label_id, const _VtxGetter& getter, const _TriGetter
         const ImPlot3DSpec& s = n.Spec;
 
         // Render fill
-        if (getter.Count >= 3 && n.RenderFill && !ImHasFlag(spec.Flags, ImPlot3DMeshFlags_NoFill))
-            RenderPrimitives2<RendererTriangleFill>(getter_triangles, GetterConstColor(ImGui::GetColorU32(s.FillColor)));
+        if (getter.Count >= 3 && n.RenderFill && !ImHasFlag(spec.Flags, ImPlot3DMeshFlags_NoFill)) {
+            if (s.FillColors != nullptr)
+                RenderPrimitives2<RendererTriangleFill>(getter_triangles, GetterIdxColor(s.FillColors, getter_triangles.Count, s.FillAlpha));
+            else
+                RenderPrimitives2<RendererTriangleFill>(getter_triangles, GetterConstColor(ImGui::GetColorU32(s.FillColor)));
+        }
 
         // Render lines
-        if (getter.Count >= 2 && n.RenderLine && !n.IsAutoLine && !ImHasFlag(spec.Flags, ImPlot3DMeshFlags_NoLines))
-            RenderPrimitives2<RendererLineSegments>(GetterTriangleLines<_TriGetter>(getter_triangles), GetterConstColor(ImGui::GetColorU32(s.LineColor)), s.LineWeight);
+        if (getter.Count >= 2 && n.RenderLine && !n.IsAutoLine && !ImHasFlag(spec.Flags, ImPlot3DMeshFlags_NoLines)) {
+            if (s.LineColors != nullptr)
+                RenderPrimitives2<RendererLineSegments>(GetterTriangleLines<_TriGetter>(getter_triangles), GetterIdxColor(s.LineColors, getter_triangles.Count), s.LineWeight);
+            else
+                RenderPrimitives2<RendererLineSegments>(GetterTriangleLines<_TriGetter>(getter_triangles), GetterConstColor(ImGui::GetColorU32(s.LineColor)), s.LineWeight);
+        }
 
         // Render markers
-        if (s.Marker != ImPlot3DMarker_None && !ImHasFlag(spec.Flags, ImPlot3DMeshFlags_NoMarkers)) {
-            const ImU32 col_line = ImGui::GetColorU32(s.MarkerLineColor);
-            const ImU32 col_fill = ImGui::GetColorU32(s.MarkerFillColor);
-            RenderMarkers(getter, s.Marker, s.MarkerSize, n.RenderMarkerFill, col_fill, n.RenderMarkerLine, col_line, s.LineWeight);
-        }
+        if (s.Marker != ImPlot3DMarker_None && !ImHasFlag(spec.Flags, ImPlot3DMeshFlags_NoMarkers))
+            RenderColoredMarkers(getter, n);
 
         EndItem();
     }


### PR DESCRIPTION
# Per-Index Color/Size Support with ImPlot3DSpec

Closes #144

<p align="center">
<img width="300" height="394" alt="image" src="https://github.com/user-attachments/assets/3a2104d6-cb90-48de-a694-efca753aa53d"/>
<img width="300" height="396" alt="image" src="https://github.com/user-attachments/assets/e0151136-268c-46a6-8f53-63435f5eb1f4"/>
</p>

<p align="center">
<img width="300" height="395" alt="image" src="https://github.com/user-attachments/assets/8f77335a-09b4-4fdf-9835-dfe9855182cc"/>
<img width="300" height="397" alt="image" src="https://github.com/user-attachments/assets/59ea8521-9f2d-4486-9579-5a240f62bfee"/>
</p>

## Summary

This PR introduces per-index color and size support across ImPlot3D plot types, just like implemented for ImPlot in https://github.com/epezent/implot/pull/672. Users can now pass arrays of colors and sizes to apply a different color or size to each vertex, segment, or marker in their plots, enabling rich visualizations with color-coded spatial data.

It also overhauls `PlotMesh` with a new API matching the rest of the library, and adds per-index color support to meshes with a documented color indexing model.

---

## New Properties

Five new `ImPlot3DSpec` properties have been added:

| Property | Type | Description |
|---|---|---|
| `ImPlot3DProp_LineColors` | `ImU32*` | Per-segment/vertex colors for lines |
| `ImPlot3DProp_FillColors` | `ImU32*` | Per-vertex colors for filled surfaces |
| `ImPlot3DProp_MarkerLineColors` | `ImU32*` | Per-marker outline colors |
| `ImPlot3DProp_MarkerFillColors` | `ImU32*` | Per-marker fill colors |
| `ImPlot3DProp_MarkerSizes` | `float*` | Per-marker sizes |

---

## Supported Plot Types

| Plot Type | `LineColors` | `FillColors` | `MarkerLineColors` | `MarkerFillColors` | `MarkerSizes` |
|---|---|---|---|---|---|
| `PlotScatter` | — | — | ✓ | ✓ | ✓ |
| `PlotLine` | ✓ | — | ✓ | ✓ | ✓ |
| `PlotTriangle` | ✓ | ✓ | ✓ | ✓ | ✓ |
| `PlotQuad` | ✓ | ✓ | ✓ | ✓ | ✓ |
| `PlotSurface` | ✓ | ✓ | ✓ | ✓ | ✓ |
| `PlotMesh` | ✓ | ✓ | ✓ | ✓ | ✓ |

---

## PlotMesh API Update

`PlotMesh` now accepts separate coordinate arrays, consistent with `PlotLine`, `PlotScatter`, and `PlotTriangle`. `Spec.Offset` and `Spec.Stride` apply to the vertex arrays only, not the index buffer. The old `ImPlot3DPoint*` overload is deprecated and will be removed in v1.0.

```cpp
// Before (deprecated)
ImPlot3D::PlotMesh("Mesh", vtx, idxs, vtx_count, idx_count);

// After
ImPlot3D::PlotMesh("Mesh", vtx_xs, vtx_ys, vtx_zs, idxs, vtx_count, idx_count);
```

### Color array semantics for PlotMesh

| Array | Size | Indexed by |
|---|---|---|
| `FillColors` / `LineColors` | `idx_count` | Position in the index buffer (3 per triangle). Setting all 3 entries of a triangle to the same color gives flat shading; different values enable Gouraud shading (GPU-interpolated). To shade by vertex: `FillColors[i] = vtx_colors[idxs[i]]`. |
| `MarkerFillColors` / `MarkerLineColors` | `vtx_count` | Vertex index (one marker per unique vertex). |

---

## Usage

```cpp
// Scatter with per-marker colors and sizes
ImU32 fill_colors[100], line_colors[100];
float sizes[100];
// ... fill arrays ...
ImPlot3D::PlotScatter("Data", xs, ys, zs, 100, {
    ImPlot3DProp_MarkerFillColors, fill_colors,
    ImPlot3DProp_MarkerLineColors, line_colors,
    ImPlot3DProp_MarkerSizes,      sizes
});

// Line with per-segment colors
ImU32 line_colors[1001];
// ... fill array ...
ImPlot3D::PlotLine("f(x)", xs, ys, zs, 1001, {
    ImPlot3DProp_LineColors, line_colors
});

// Triangle mesh with per-vertex fill colors (Gouraud shading)
ImU32 fill_colors[18]; // one per vertex-in-order
// ... fill array ...
ImPlot3D::PlotTriangle("Mesh", xs, ys, zs, 18, {
    ImPlot3DProp_FillColors, fill_colors
});

// Indexed mesh with Gouraud shading (map vertex colors to index slots)
ImU32 idx_fill_colors[idx_count]; // one per index buffer slot
for (int i = 0; i < idx_count; i++)
    idx_fill_colors[i] = vtx_colors[idxs[i]];
ImPlot3D::PlotMesh("Duck", vtx_xs, vtx_ys, vtx_zs, idxs, vtx_count, idx_count, {
    ImPlot3DProp_Stride,     (int)sizeof(ImPlot3DPoint),
    ImPlot3DProp_FillColors, idx_fill_colors,
    ImPlot3DProp_Flags,      (int)ImPlot3DMeshFlags_NoLines
});
```

---

## Implementation Details

- **Template-based getter system**: `GetterConstColor` / `GetterIdxColor` for colors, `GetterConstSize` / `GetterIdxSize` for sizes. Lazy per-index fetching via `operator()(int idx)`. `GetterIdxColor` applies an optional alpha multiplier.
- **`RenderPrimitives` / `RenderPrimitives2` / `RenderPrimitives3`**: convenience wrappers that dispatch templated renderers, matching ImPlot's pattern.
- **`RenderColoredMarkers`**: dispatches on null checks of `MarkerSizes`, `MarkerFillColors`, `MarkerLineColors` to select const vs per-index getters, then calls the templated `RenderMarkers`.
- **Fill renderers** (`RendererTriangleFill`, `RendererQuadFill`): call the color getter per vertex index (`3*prim+v`, `4*prim+v`), enabling smooth GPU-interpolated color gradients across faces.
- **`PlotMeshEx`**: new internal helper taking separate vertex and triangle getters, used by both the new templated `PlotMesh` overload and the deprecated `ImPlot3DPoint*` fallback.
- **`GetterMeshTriangles`**: templated on three coordinate getters, replacing the old `ImPlot3DPoint*`-only struct.
- **Full backward compatibility**: all existing single-color properties continue to work unchanged. The `ImPlot3DPoint*` overload still compiles (with a deprecation warning).
- **Alpha**: per-index fill colors are multiplied by `FillAlpha` when applicable.