### PR TITLE
fix: `PlotDummy` item color

### DIFF
--- a/implot3d.cpp
+++ b/implot3d.cpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: 2024-2026 Breno Cunha Queiroz
 
-// ImPlot3D v0.4
+// ImPlot3D v0.5 WIP
 
 // Acknowledgments:
 //  ImPlot3D is heavily inspired by ImPlot

--- a/implot3d.h
+++ b/implot3d.h
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: 2024-2026 Breno Cunha Queiroz
 
-// ImPlot3D v0.4
+// ImPlot3D v0.5 WIP
 
 // Acknowledgments:
 //  ImPlot3D is heavily inspired by ImPlot
@@ -45,8 +45,8 @@
 #define IMPLOT3D_API
 #endif
 
-#define IMPLOT3D_VERSION "0.4"                // ImPlot3D version
-#define IMPLOT3D_VERSION_NUM 401              // Integer encoded version
+#define IMPLOT3D_VERSION "0.5 WIP"            // ImPlot3D version
+#define IMPLOT3D_VERSION_NUM 500              // Integer encoded version
 #define IMPLOT3D_AUTO -1                      // Deduce variable automatically
 #define IMPLOT3D_AUTO_COL ImVec4(0, 0, 0, -1) // Deduce color automatically
 #define IMPLOT3D_TMP template <typename T> IMPLOT3D_API

--- a/implot3d_demo.cpp
+++ b/implot3d_demo.cpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: 2024-2026 Breno Cunha Queiroz
 
-// ImPlot3D v0.4
+// ImPlot3D v0.5 WIP
 
 // Acknowledgments:
 //  ImPlot3D is heavily inspired by ImPlot

--- a/implot3d_internal.h
+++ b/implot3d_internal.h
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: 2024-2026 Breno Cunha Queiroz
 
-// ImPlot3D v0.4
+// ImPlot3D v0.5 WIP
 
 // Acknowledgments:
 //  ImPlot3D is heavily inspired by ImPlot

--- a/implot3d_items.cpp
+++ b/implot3d_items.cpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: 2024-2026 Breno Cunha Queiroz
 
-// ImPlot3D v0.4
+// ImPlot3D v0.5 WIP
 
 // Acknowledgments:
 //  ImPlot3D is heavily inspired by ImPlot

--- a/implot3d_items.cpp
+++ b/implot3d_items.cpp
@@ -1634,7 +1634,15 @@ void PlotText(const char* text, double x, double y, double z, double angle, cons
 }
 
 void PlotDummy(const char* label_id, const ImPlot3DSpec& spec) {
-    if (BeginItem(label_id, spec, spec.LineColor, spec.Marker))
+    // Pick the first non-auto color from the spec to override the legend icon color
+    ImVec4 item_col = spec.LineColor;
+    if (IsColorAuto(item_col))
+        item_col = spec.FillColor;
+    if (IsColorAuto(item_col))
+        item_col = spec.MarkerLineColor;
+    if (IsColorAuto(item_col))
+        item_col = spec.MarkerFillColor;
+    if (BeginItem(label_id, spec, item_col, spec.Marker))
         EndItem();
 }
 

--- a/implot3d_meshes.cpp
+++ b/implot3d_meshes.cpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: 2024-2026 Breno Cunha Queiroz
 
-// ImPlot3D v0.4
+// ImPlot3D v0.5 WIP
 
 // Acknowledgments:
 //  ImPlot3D is heavily inspired by ImPlot


### PR DESCRIPTION
Fixes #186 

`PlotDummy` is used mainly to set the legend color, but right now the color is only set if the user sets the `LineColor`, which is an arbitrary choice. To avoid this, this PR makes it possible to set the legend color by setting any of the color properties.

`PlotDummy` now picks the first non-auto color from the spec, in priority order: `LineColor` → `FillColor` → `MarkerLineColor` → `MarkerFillColor`.