### PR TITLE
feat: legend scrolling

### DIFF
--- a/implot3d.cpp
+++ b/implot3d.cpp
@@ -350,6 +350,28 @@ ImVec2 CalcLegendSize(ImPlot3DItemGroup& items, const ImVec2& pad, const ImVec2&
     return legend_size;
 }
 
+bool ClampLegendRect(ImRect& legend_rect, const ImRect& outer_rect, const ImVec2& pad) {
+    bool clamped = false;
+    ImRect outer_rect_pad(outer_rect.Min + pad, outer_rect.Max - pad);
+    if (legend_rect.Min.x < outer_rect_pad.Min.x) {
+        legend_rect.Min.x = outer_rect_pad.Min.x;
+        clamped = true;
+    }
+    if (legend_rect.Min.y < outer_rect_pad.Min.y) {
+        legend_rect.Min.y = outer_rect_pad.Min.y;
+        clamped = true;
+    }
+    if (legend_rect.Max.x > outer_rect_pad.Max.x) {
+        legend_rect.Max.x = outer_rect_pad.Max.x;
+        clamped = true;
+    }
+    if (legend_rect.Max.y > outer_rect_pad.Max.y) {
+        legend_rect.Max.y = outer_rect_pad.Max.y;
+        clamped = true;
+    }
+    return clamped;
+}
+
 void ShowLegendEntries(ImPlot3DItemGroup& items, const ImRect& legend_bb, const ImVec2& pad, const ImVec2& spacing, bool vertical,
                        ImDrawList& draw_list) {
     const float txt_ht = ImGui::GetTextLineHeight();
@@ -434,18 +456,54 @@ void RenderLegend() {
     const ImVec2 legend_size = CalcLegendSize(plot.Items, gp.Style.LegendInnerPadding, gp.Style.LegendSpacing, !legend_horz);
     const ImVec2 legend_pos = GetLocationPos(plot.PlotRect, legend_size, legend.Location, gp.Style.LegendPadding);
     legend.Rect = ImRect(legend_pos, legend_pos + legend_size);
+    legend.RectClamped = legend.Rect;
+    const bool legend_scrollable = ClampLegendRect(legend.RectClamped, plot.PlotRect, gp.Style.LegendPadding);
 
-    // Test hover
-    legend.Hovered = legend.Rect.Contains(IO.MousePos);
+    // Test hover (using the clamped rect so off-screen overflow does not register)
+    // clang-format off
+    const ImGuiButtonFlags legend_button_flags = ImGuiButtonFlags_AllowOverlap
+                                               | ImGuiButtonFlags_PressedOnClick
+                                               | ImGuiButtonFlags_PressedOnDoubleClick
+                                               | ImGuiButtonFlags_MouseButtonLeft
+                                               | ImGuiButtonFlags_MouseButtonRight
+                                               | ImGuiButtonFlags_MouseButtonMiddle
+                                               | ImGuiButtonFlags_FlattenChildren;
+    // clang-format on
+    ImGui::KeepAliveID(plot.Items.ID);
+    ImGui::ButtonBehavior(legend.RectClamped, plot.Items.ID, &legend.Hovered, &legend.Held, legend_button_flags);
+    legend.Hovered = legend.Hovered || legend.RectClamped.Contains(IO.MousePos);
 
-    // Render background
+    // Handle legend scrolling
+    if (legend_scrollable) {
+        if (legend.Hovered) {
+            ImGui::SetKeyOwner(ImGuiKey_MouseWheelY, plot.Items.ID);
+            if (IO.MouseWheel != 0.0f) {
+                ImVec2 max_step = legend.Rect.GetSize() * 0.67f;
+                float font_size = ImGui::GetFontSize();
+                float scroll_step = ImFloor(ImMin(2 * font_size, max_step.x));
+                legend.Scroll.x += scroll_step * IO.MouseWheel;
+                legend.Scroll.y += scroll_step * IO.MouseWheel;
+            }
+        }
+        const ImVec2 min_scroll_offset = legend.RectClamped.GetSize() - legend.Rect.GetSize();
+        legend.Scroll.x = ImClamp(legend.Scroll.x, min_scroll_offset.x, 0.0f);
+        legend.Scroll.y = ImClamp(legend.Scroll.y, min_scroll_offset.y, 0.0f);
+        const ImVec2 scroll_offset = legend_horz ? ImVec2(legend.Scroll.x, 0) : ImVec2(0, legend.Scroll.y);
+        ImVec2 legend_offset = legend.RectClamped.Min - legend.Rect.Min + scroll_offset;
+        legend.Rect.Min += legend_offset;
+        legend.Rect.Max += legend_offset;
+    } else {
+        legend.Scroll = ImVec2(0, 0);
+    }
+
+    // Render background and entries (clipped to the clamped rect to hide scrolled-off overflow)
     ImU32 col_bg = GetStyleColorU32(ImPlot3DCol_LegendBg);
     ImU32 col_bd = GetStyleColorU32(ImPlot3DCol_LegendBorder);
-    draw_list->AddRectFilled(legend.Rect.Min, legend.Rect.Max, col_bg);
-    draw_list->AddRect(legend.Rect.Min, legend.Rect.Max, col_bd);
-
-    // Render legends
+    ImGui::PushClipRect(legend.RectClamped.Min, legend.RectClamped.Max, true);
+    draw_list->AddRectFilled(legend.RectClamped.Min, legend.RectClamped.Max, col_bg);
     ShowLegendEntries(plot.Items, legend.Rect, gp.Style.LegendInnerPadding, gp.Style.LegendSpacing, !legend_horz, *draw_list);
+    draw_list->AddRect(legend.RectClamped.Min, legend.RectClamped.Max, col_bd);
+    ImGui::PopClipRect();
 }
 
 //-----------------------------------------------------------------------------
@@ -1705,6 +1763,7 @@ bool BeginPlot(const char* title_id, const ImVec2& size, ImPlot3DFlags flags) {
 
     // Populate plot
     plot.ID = ID;
+    plot.Items.ID = ID - 1;
     plot.JustCreated = just_created;
     if (just_created) {
         plot.Rotation = plot.InitialRotation;
@@ -4224,8 +4283,10 @@ void ImPlot3D::ShowMetricsWindow(bool* p_popen) {
                 }
             }
         }
-        if (show_legend_rects && plot.Items.GetLegendCount() > 0)
+        if (show_legend_rects && plot.Items.GetLegendCount() > 0) {
             fg.AddRect(plot.Items.Legend.Rect.Min, plot.Items.Legend.Rect.Max, IM_COL32(255, 192, 0, 255));
+            fg.AddRect(plot.Items.Legend.RectClamped.Min, plot.Items.Legend.RectClamped.Max, IM_COL32(255, 128, 0, 255));
+        }
     }
     if (ImGui::TreeNode("Plots", "Plots (%d)", n_plots)) {
         for (int p = 0; p < n_plots; ++p) {

--- a/implot3d_demo.cpp
+++ b/implot3d_demo.cpp
@@ -805,6 +805,9 @@ void DemoLegendOptions() {
     ImGui::SliderFloat2("LegendInnerPadding", (float*)&ImPlot3D::GetStyle().LegendInnerPadding, 0.0f, 10.0f, "%.0f");
     ImGui::SliderFloat2("LegendSpacing", (float*)&ImPlot3D::GetStyle().LegendSpacing, 0.0f, 5.0f, "%.0f");
 
+    static int num_dummy_items = 25;
+    ImGui::SliderInt("Num Dummy Items (Demo Scrolling)", &num_dummy_items, 0, 100);
+
     if (ImPlot3D::BeginPlot("Legend Options Demo", ImVec2(-1, 0))) {
         ImPlot3D::SetupAxes("X-Axis", "Y-Axis", "Z-Axis");
         ImPlot3D::SetupAxesLimits(-1, 1, -1, 1, -1, 1);
@@ -837,6 +840,13 @@ void DemoLegendOptions() {
         ImPlot3D::PlotLine("Helix A", xs1, ys1, zs1, count);
         ImPlot3D::PlotLine("Helix B##IDText", xs2, ys2, zs2, count); // Text after ## used for ID only
         ImPlot3D::PlotLine("##NotListed", xs3, ys3, zs3, count);     // Plotted, but not added to legend
+
+        // Add dummy items to demonstrate legend scrolling (scroll the mouse wheel over the legend)
+        for (int i = 0; i < num_dummy_items; ++i) {
+            char label[16];
+            snprintf(label, sizeof(label), "Item %03d", i);
+            ImPlot3D::PlotDummy(label);
+        }
 
         ImPlot3D::EndPlot();
     }

--- a/implot3d_internal.h
+++ b/implot3d_internal.h
@@ -344,9 +344,11 @@ struct ImPlot3DLegend {
     ImPlot3DLegendFlags PreviousFlags;
     ImPlot3DLocation Location;
     ImPlot3DLocation PreviousLocation;
+    ImVec2 Scroll;
     ImVector<int> Indices;
     ImGuiTextBuffer Labels;
     ImRect Rect;
+    ImRect RectClamped;
     bool Hovered;
     bool Held;
 
@@ -354,6 +356,7 @@ struct ImPlot3DLegend {
         PreviousFlags = Flags = ImPlot3DLegendFlags_None;
         Hovered = Held = false;
         PreviousLocation = Location = ImPlot3DLocation_NorthWest;
+        Scroll = ImVec2(0, 0);
     }
 
     void Reset() {
@@ -364,12 +367,14 @@ struct ImPlot3DLegend {
 
 // Holds items
 struct ImPlot3DItemGroup {
+    ImGuiID ID;
     ImPool<ImPlot3DItem> ItemPool;
     ImPlot3DLegend Legend;
     int ColormapIdx;
     ImPlot3DMarker MarkerIdx;
 
     ImPlot3DItemGroup() {
+        ID = 0;
         ColormapIdx = 0;
         MarkerIdx = 0;
     }


### PR DESCRIPTION
Closes #193

This pull request adds legend scrolling functionality to the 3D plot legend in ImPlot3D, improves legend rendering and interaction, and updates the demo to showcase the new feature. The main changes include implementing scrollable legends, updating legend state and rendering logic, and enhancing the demo for better usability.

<div align="center">
<img width="480" height="256" alt="Kooha-2026-07-14-09-04-07" src="https://github.com/user-attachments/assets/24e35d9d-2f00-4b09-8986-bd269c38c31e" />
</div>

**Legend scrolling and interaction:**

* Added a `ClampLegendRect` function to restrict the legend rectangle within the plot bounds, and updated legend rendering to support scrolling when the legend content exceeds available space. Mouse wheel scrolling is enabled when hovering over the legend. (`implot3d.cpp`) [[1]](diffhunk://#diff-9096062e4ac4b4bd6a2845421c39bc5c9aef29aad2ee447d5f7251f9eb6390c0R353-R374) [[2]](diffhunk://#diff-9096062e4ac4b4bd6a2845421c39bc5c9aef29aad2ee447d5f7251f9eb6390c0R459-R506)
* Updated the legend's hover and interaction logic to use the clamped rectangle, preventing off-screen overflow from registering as hovered. (`implot3d.cpp`)

**Legend state and structure updates:**

* Added `Scroll` and `RectClamped` members to `ImPlot3DLegend`, and an `ID` member to `ImPlot3DItemGroup`, initializing and updating these as needed. (`implot3d_internal.h`, `implot3d.cpp`) [[1]](diffhunk://#diff-516068f1d57d2dec479da125b27f6486935defdd36f08ef8812c466391847158R347-R359) [[2]](diffhunk://#diff-516068f1d57d2dec479da125b27f6486935defdd36f08ef8812c466391847158R370-R377) [[3]](diffhunk://#diff-9096062e4ac4b4bd6a2845421c39bc5c9aef29aad2ee447d5f7251f9eb6390c0R1766)
* Updated the metrics window to draw both the unclamped and clamped legend rectangles for debugging. (`implot3d.cpp`)

**Demo and usability improvements:**

* Enhanced the legend demo with a slider to add dummy items, allowing users to test and visualize legend scrolling. (`implot3d_demo.cpp`) [[1]](diffhunk://#diff-f3d36a3563642cdbc6a9d76cee17960336f5a2ad08a83fab7184c0dab4291232R808-R810) [[2]](diffhunk://#diff-f3d36a3563642cdbc6a9d76cee17960336f5a2ad08a83fab7184c0dab4291232R844-R850)