### PR TITLE
fix: line rendering with ImGui v1.93+

### DIFF
--- a/implot3d_items.cpp
+++ b/implot3d_items.cpp
@@ -80,6 +80,26 @@
     } while (0)
 
 IMPLOT3D_INLINE void GetLineRenderProps(const ImDrawList3D& draw_list_3d, float& half_weight, ImVec2& tex_uv0, ImVec2& tex_uv1) {
+#if IMGUI_VERSION_NUM >= 19299 || defined(IM_DRAWLIST_TEX_LINES_SAMPLE_COUNT)
+    // ImGui 1.93+ bakes anti-aliased line textures with a new layout and picks them via ImDrawList::_SelectLineTexture().
+    // ImDrawList3D is not an ImDrawList, so we inline the same texture/fringe selection here (assuming _FringeScale == 1).
+    const float screen_thickness = half_weight * 2.0f; // callers clamp weight to >= 1, so screen_thickness >= 1
+    if (ImPlot3D::ImHasFlag(draw_list_3d._Flags, ImDrawFlags_AALines)) {
+        int texture_idx;
+        if (screen_thickness <= IM_DRAWLIST_TEX_LINES_DETAILED_WIDTH)
+            texture_idx = (int)((screen_thickness - 1.0f) * IM_DRAWLIST_TEX_LINES_SAMPLE_COUNT + 0.5f) + (IM_DRAWLIST_TEX_LINES_WIDTH_MAX + 1);
+        else if (screen_thickness < (float)IM_DRAWLIST_TEX_LINES_WIDTH_MAX - 1.5f)
+            texture_idx = (int)(screen_thickness + 0.5f);
+        else
+            texture_idx = IM_DRAWLIST_TEX_LINES_WIDTH_MAX - 1;
+        const ImVec4 tex_uvs = draw_list_3d._SharedData->TexUvLines[texture_idx]; // (u0, u1, v, 1/thickness)
+        tex_uv0 = ImVec2(tex_uvs.x, tex_uvs.z);
+        tex_uv1 = ImVec2(tex_uvs.y, tex_uvs.z);
+        half_weight += 0.5f * screen_thickness * tex_uvs.w; // add half of the anti-aliasing fringe
+    } else {
+        tex_uv0 = tex_uv1 = draw_list_3d._SharedData->TexUvWhitePixel;
+    }
+#else
     const bool aa = ImPlot3D::ImHasFlag(draw_list_3d._Flags, ImDrawListFlags_AntiAliasedLines) &&
                     ImPlot3D::ImHasFlag(draw_list_3d._Flags, ImDrawListFlags_AntiAliasedLinesUseTex);
     if (aa) {
@@ -90,6 +110,7 @@ IMPLOT3D_INLINE void GetLineRenderProps(const ImDrawList3D& draw_list_3d, float&
     } else {
         tex_uv0 = tex_uv1 = draw_list_3d._SharedData->TexUvWhitePixel;
     }
+#endif
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
ImGui `1.93.0`'s `ImDrawList` rework changed the layout of the baked anti-aliased line
texture table (`ImDrawListSharedData::TexUvLines[]`, now `(u0, u1, v, 1/thickness)`) and
selects entries through the new `ImDrawList::_SelectLineTexture()` helper. ImPlot3D reads
that table directly in `GetLineRenderProps()`, so against ImGui ≥ 1.93 it picked the wrong
UVs and **anti-aliased lines rendered incorrectly / were not visible**.

This ports the upstream ImPlot fix to ImPlot3D.

## Changes

- `GetLineRenderProps()` now mirrors `ImDrawList::_SelectLineTexture()` for the new
  `TexUvLines[]` layout and adds the anti-aliasing fringe to `half_weight`.
- Since `ImDrawList3D` is not an `ImDrawList`, the selection logic is inlined against
  `_SharedData` (with `_FringeScale == 1`) instead of calling the method.
- Guarded with `#if IMGUI_VERSION_NUM >= 19299 || defined(IM_DRAWLIST_TEX_LINES_SAMPLE_COUNT)`;
  the pre-1.93 path is kept unchanged for older ImGui.

## References

- Ports ImPlot [#712 – Refactor: update to upcoming v1.93 changes](https://github.com/epezent/implot/pull/712)
  (commit `7eeb916`, *"use `ImDrawList::_SelectLineTexture()`"*).
- ImGui [ocornut/imgui#9504](https://github.com/ocornut/imgui/issues/9504) – the `ImDrawList` v1.93 changes.
- ImPlot [#711](https://github.com/epezent/implot/pull/711) (`AddLineH()` / `AddLineV()` wrappers,
  added in ImGui 1.92.8) is **not** ported: every ImPlot3D line is a 3D-projected segment at an
  arbitrary screen angle, so there are no axis-aligned `AddLine()` calls to replace.